### PR TITLE
Update mixin compatibilityLevel to Java 17

### DIFF
--- a/src/main/resources/create.mixins.json
+++ b/src/main/resources/create.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "priority": 1100,
   "package": "com.simibubi.create.foundation.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "refmap": "create-refmap.json",
   "mixins": [
     "CustomItemUseEffectsMixin"

--- a/src/main/resources/create_lib.mixins.json
+++ b/src/main/resources/create_lib.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.simibubi.create.lib.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "accessor.AbstractMinecartAccessor",
     "accessor.AbstractSelectionList$EntryAccessor",


### PR DESCRIPTION
This pull request changes the compatibilityLevel of mixins to Java 17 from Java 16. Doing so will fix issues with mixins using Java 17 features and will remove the redundant `Compatibility level set to JAVA_16` log message when used in a setup where all other mods have done the same. A similar change should also be made to [Registrate-Refabricated](https://github.com/Create-Fabric/Registrate-Refabricated) as it's compatibilityLevel is set to Java 8. This also applies to the Fabric version of Flywheel if this hasn't been done already.