### PR TITLE
epic one liner fix #433

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerTileEntity.java
@@ -222,6 +222,7 @@ public class BlazeBurnerTileEntity extends SmartTileEntity {
 		TransactionCallback.onSuccess(ctx, () -> {
 			activeFuel = finalNewFuel;
 			remainingBurnTime = finalNewBurnTime;
+			updateBlockState();
 		});
 
 		if (level.isClientSide) {


### PR DESCRIPTION
seems like the transaction callback executes after updating the blockstate