### PR TITLE
Add recipe viewer selector for development environments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,61 @@ version = mod_version + (dev && buildNumber != null ? "-${buildNumber}" : '')
 group = project.maven_group
 archivesBaseName = "create-${project.minecraft_version}"
 
+def localProps = new Properties()
+// there is no API method in Gradle to retrieve the path to .gradle
+// this is the same way Loom does it
+def localPropsFile = file(".gradle/create/local.properties")
+
+import javax.swing.JOptionPane
+import javax.swing.UIManager
+
+def openRecipeViewerDialog(localProps, localPropsFile) {
+    try {
+        // only exists on Linux and is not the default for some reason
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel")
+    } catch (e) {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
+    }
+    def choices = new String[] {
+        'EMI',
+        'REI',
+        'JEI'
+    }
+    def choice = JOptionPane.showOptionDialog(null,
+        """
+        <html>
+        <b>Which recipe viewer do you want to use in the Create development environment?</b><br/><br/>
+        You can change your choice later by running the <code>chooseRecipeViewer</code> Gradle task.
+        </html>
+        """.trim().replace("\n", ""),
+        'Create',
+        JOptionPane.DEFAULT_OPTION,
+        JOptionPane.QUESTION_MESSAGE,
+        null,
+        choices,
+        project.default_recipe_viewer.toUpperCase(Locale.ROOT)
+    )
+    if (choice >= 0 && choice < choices.length) {
+        localPropsFile.getParentFile().mkdirs()
+        localProps.setProperty("recipe_viewer", choices[choice].toLowerCase(Locale.ROOT))
+        localPropsFile.withWriter { localProps.store(it, "Create local build configuration") }
+    }
+}
+
+if (localPropsFile.exists()) {
+    localPropsFile.withReader { localProps.load(it) }
+}
+
+if (!localProps.containsKey("recipe_viewer")) {
+    if (!java.awt.GraphicsEnvironment.isHeadless()) {
+        openRecipeViewerDialog(localProps, localPropsFile)
+    } else {
+        println "No GUI available, using default recipe viewer "+project.default_recipe_viewer
+    }
+}
+
+def recipeViewer = localProps.getOrDefault("recipe_viewer", project.default_recipe_viewer)
+
 repositories {
     mavenCentral()
     mavenLocal()
@@ -79,7 +134,6 @@ dependencies {
     // EMI
     modCompileOnly("dev.emi:emi:${project.emi_version}") { transitive = false }
 
-    def recipeViewer = project.recipe_viewer
     if (recipeViewer == "emi") {
         modRuntimeOnly("dev.emi:emi:${project.emi_version}")  { transitive = false }
     } else if (recipeViewer == "rei") {
@@ -204,6 +258,12 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
     it.options.release = Integer.parseInt(sourceCompatibility)
+}
+
+task chooseRecipeViewer {
+    doFirst {
+        openRecipeViewerDialog(localProps, localPropsFile)
+    }
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,5 +55,6 @@ emi_version = 0.2.0+1.18.2
 # https://www.curseforge.com/minecraft/mc-mods/jei/files/all
 jei_version = 10.1.1.231
 
-# What recipe viewer to use ('emi', 'rei', or 'jei'. if you change it, don't push it)
-recipe_viewer = rei
+# Default recipe viewer to use when one has not been set explicitly.
+# Don't change this for personal use; run the "chooseRecipeViewer" task.
+default_recipe_viewer = rei


### PR DESCRIPTION
I heard there was some ongoing strife in the project related to which recipe viewer should be default. So, naturally, I overengineered a solution and am making a PR I expect to be rejected.

This moves the recipe viewer choice into the `.gradle` directory and adds a Swing GUI prompt to ask developers for their preferred recipe viewer, and adds a `chooseRecipeViewer` task to change it again later if desired.

If run in an environment with no GUI available (e.g. CI) it will silently use the default from gradle.properties.

The dialog looks like this on Linux with Breeze Dark (note that the button order is OS-dependent, and this is actually inverse from how it is defined in the source):

![image](https://user-images.githubusercontent.com/6185037/180347374-70a7d4bb-bc52-4dad-9fdd-a1784498015b.png)

The configured default is used as the default highlighted button, which will be accepted if simply hitting Enter/etc when the dialog is opened.

I wanted to add links to the various projects in the dialog body, but HTML links don't work in JOptionPanes for some reason, and I didn't want to create a full custom Swing GUI for something this silly.

This is put way up in the top of the file to ensure it runs before dependency resolution, as otherwise it takes multiple minutes for the dialog to show up in a fresh clone.

A Swing GUI is used instead of a command-line prompt as that doesn't work from within IDEs, and the Gradle Daemon also breaks accepting input on the console. (Additionally, it would halt CI builds unless special support was added.)