### PR TITLE
Add support for filling Botania's petal apothecaries with spouts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ repositories {
             includeGroup("com.jamieswhiteshirt")
         }
     }
+    maven { url = "https://maven.blamejared.com/vazkii/botania/Botania/" }
 }
 
 dependencies {
@@ -102,6 +103,7 @@ def compat(DependencyHandler deps) {
     deps.modImplementation("com.terraformersmc:modmenu:${project.modmenu_version}")
     deps.modCompileOnly("maven.modrinth:sandwichable:1.2+1.18.2")
     deps.modImplementation("dev.emi:trinkets:${project.trinkets_version}") { exclude(group: "com.terraformersmc") }
+    deps.modImplementation("vazkii.botania:Botania:${project.botania_version}")
 }
 
 // setup the three recipe viewer mods

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,6 +59,8 @@ trinkets_version = 3.3.1
 emi_version = 0.3.4+1.18.2
 # https://www.curseforge.com/minecraft/mc-mods/jei/files/all
 jei_version = 10.1.1.231
+# https://maven.blamejared.com/vazkii/botania/Botania/
+botania_version = 1.18.2-435-FABRIC
 
 # What recipe viewer to use ('emi', 'rei', or 'jei'. if you change it, don't push it)
 recipe_viewer = emi

--- a/src/main/java/com/simibubi/create/api/behaviour/BlockSpoutingBehaviour.java
+++ b/src/main/java/com/simibubi/create/api/behaviour/BlockSpoutingBehaviour.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import com.simibubi.create.Create;
+import com.simibubi.create.compat.botania.ApothecaryFilling;
 import com.simibubi.create.compat.tconstruct.SpoutCasting;
 import com.simibubi.create.content.contraptions.fluids.actors.SpoutTileEntity;
 import io.github.fabricators_of_create.porting_lib.util.FluidStack;
@@ -48,6 +49,7 @@ public abstract class BlockSpoutingBehaviour {
 
 	public static void registerDefaults() {
 		addCustomSpoutInteraction(Create.asResource("ticon_casting"), new SpoutCasting());
+		addCustomSpoutInteraction(Create.asResource("botania_apothecary_filling"), new ApothecaryFilling());
 	}
 
 }

--- a/src/main/java/com/simibubi/create/compat/Mods.java
+++ b/src/main/java/com/simibubi/create/compat/Mods.java
@@ -15,7 +15,8 @@ public enum Mods {
 	TCONSTRUCT,
 	SANDWICHABLE,
 	TRINKETS,
-	MODMENU;
+	MODMENU,
+	BOTANIA;
 
 	private final boolean loaded;
 

--- a/src/main/java/com/simibubi/create/compat/botania/ApothecaryFilling.java
+++ b/src/main/java/com/simibubi/create/compat/botania/ApothecaryFilling.java
@@ -55,7 +55,6 @@ public class ApothecaryFilling extends BlockSpoutingBehaviour {
 			return 0;
 		}
 
-		System.out.println(availableFluid.getAmount());
 		// don't insert if we have less than a bucket's worth of fluid
 		if (availableFluid.getAmount() < FluidConstants.BUCKET) {
 			return 0;

--- a/src/main/java/com/simibubi/create/compat/botania/ApothecaryFilling.java
+++ b/src/main/java/com/simibubi/create/compat/botania/ApothecaryFilling.java
@@ -1,0 +1,81 @@
+package com.simibubi.create.compat.botania;
+
+import com.simibubi.create.api.behaviour.BlockSpoutingBehaviour;
+import com.simibubi.create.compat.Mods;
+import com.simibubi.create.content.contraptions.fluids.actors.SpoutTileEntity;
+import com.simibubi.create.foundation.config.AllConfigs;
+import com.simibubi.create.foundation.utility.RegisteredObjects;
+
+import io.github.fabricators_of_create.porting_lib.util.FluidStack;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
+import vazkii.botania.api.block.IPetalApothecary;
+import vazkii.botania.common.block.tile.TileAltar;
+
+public class ApothecaryFilling extends BlockSpoutingBehaviour {
+
+	static Boolean BOTANIA_PRESENT = null;
+
+	private final ResourceLocation APOTHECARY = new ResourceLocation("botania", "altar");
+
+	@Override
+	public long fillBlock(Level level, BlockPos pos, SpoutTileEntity spout, FluidStack availableFluid,
+		boolean simulate) {
+		if (!enabled())
+			return 0;
+
+		BlockEntity te = level.getBlockEntity(pos);
+		if (te == null)
+			return 0;
+
+		ResourceLocation registryName = RegisteredObjects.getKeyOrThrow(te.getType());
+		if (!registryName.equals(APOTHECARY))
+			return 0;
+
+		// this shouldn't fail but... better safe than sorry.
+		if (!(te instanceof TileAltar apothecary))
+			return 0;
+		// don't insert if it's not empty
+		if (apothecary.getFluid() != IPetalApothecary.State.EMPTY)
+			return 0;
+
+		IPetalApothecary.State fluidState;
+
+		Fluid fluid = availableFluid.getType().getFluid();
+		if (fluid == Fluids.WATER) {
+			fluidState = IPetalApothecary.State.WATER;
+		} else if (fluid == Fluids.LAVA) {
+			fluidState = IPetalApothecary.State.LAVA;
+		} else {
+			return 0;
+		}
+
+		System.out.println(availableFluid.getAmount());
+		// don't insert if we have less than a bucket's worth of fluid
+		if (availableFluid.getAmount() < FluidConstants.BUCKET) {
+			return 0;
+		}
+
+		long inserted = FluidConstants.BUCKET;
+		if (!simulate) {
+			availableFluid.shrink(inserted);
+			apothecary.setFluid(fluidState);
+		}
+
+		return inserted;
+	}
+
+	private boolean enabled() {
+		if (BOTANIA_PRESENT == null)
+			BOTANIA_PRESENT = Mods.BOTANIA.isLoaded();
+		if (!BOTANIA_PRESENT)
+			return false;
+		return AllConfigs.SERVER.recipes.allowFillingBySpout.get();
+	}
+
+}

--- a/src/main/java/com/simibubi/create/compat/botania/ApothecaryFilling.java
+++ b/src/main/java/com/simibubi/create/compat/botania/ApothecaryFilling.java
@@ -38,7 +38,7 @@ public class ApothecaryFilling extends BlockSpoutingBehaviour {
 			return 0;
 
 		// this shouldn't fail but... better safe than sorry.
-		if (!(te instanceof TileAltar apothecary))
+		if (!(te instanceof IPetalApothecary apothecary))
 			return 0;
 		// don't insert if it's not empty
 		if (apothecary.getFluid() != IPetalApothecary.State.EMPTY)

--- a/src/main/java/com/simibubi/create/foundation/config/CRecipes.java
+++ b/src/main/java/com/simibubi/create/foundation/config/CRecipes.java
@@ -14,6 +14,7 @@ public class CRecipes extends ConfigBase {
 	public final ConfigBool allowStonecuttingOnSaw = b(true, "allowStonecuttingOnSaw", Comments.allowStonecuttingOnSaw);
 	public final ConfigBool allowWoodcuttingOnSaw = b(true, "allowWoodcuttingOnSaw", Comments.allowWoodcuttingOnSaw);
 	public final ConfigBool allowCastingBySpout = b(true, "allowCastingBySpout", Comments.allowCastingBySpout);
+	public final ConfigBool allowFillingBySpout = b(true, "allowFillingBySpout", Comments.allowFillingBySpout);
 	public final ConfigBool displayLogStrippingRecipes = b(true, "displayLogStrippingRecipes", Comments.displayLogStrippingRecipes);
 	public final ConfigInt lightSourceCountForRefinedRadiance =
 		i(10, 1, "lightSourceCountForRefinedRadiance", Comments.refinedRadiance);
@@ -44,6 +45,8 @@ public class CRecipes extends ConfigBase {
 			"Allow any Druidcraft woodcutter recipes to be processed by a Mechanical Saw.";
 		static String allowCastingBySpout =
 			"Allow Spouts to interact with Casting Tables and Basins from Tinkers' Construct.";
+		static String allowFillingBySpout =
+			"Allow Spouts to fill the Petal Apothecary from Botania.";
 		static String refinedRadiance =
 			"The amount of Light sources destroyed before Chromatic Compound turns into Refined Radiance.";
 		static String refinedRadianceRecipe = "Allow the standard in-world Refined Radiance recipes.";


### PR DESCRIPTION
This is kind of a pet peeve of mine so I'm totally fine if this doesn't make it to the mod itself, but personally I feel like this is as reasonable as [filling TConstruct's casting tables and basins with spouts](https://github.com/Fabricators-of-Create/Create/blob/mc1.18/fabric/dev/src/main/java/com/simibubi/create/compat/tconstruct/SpoutCasting.java).

A demo: https://cdn.discordapp.com/attachments/834483421068918785/1040964588541317160/2022-11-12_19-52-13.mp4

This will probably work in 1.19 as-is (?) But if it doesn't, I'm happy to port it :3