### PR TITLE
Memory leak fix for ClientWorlds being retained by Create

### DIFF
--- a/src/main/java/com/simibubi/create/events/CommonEvents.java
+++ b/src/main/java/com/simibubi/create/events/CommonEvents.java
@@ -2,6 +2,7 @@ package com.simibubi.create.events;
 
 import java.util.concurrent.Executor;
 
+import io.github.fabricators_of_create.porting_lib.event.client.ClientWorldEvents;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.Commands;
 
@@ -247,7 +248,9 @@ public class CommonEvents {
 		ServerEntityEvents.ENTITY_LOAD.register(CommonEvents::onEntityAdded);
 		ServerLifecycleEvents.SERVER_STOPPED.register(CommonEvents::serverStopping);
 		ServerWorldEvents.LOAD.register(CommonEvents::onLoadWorld);
+		ClientWorldEvents.LOAD.register(CommonEvents::onLoadWorld);
 		ServerWorldEvents.UNLOAD.register(CommonEvents::onUnloadWorld);
+		ClientWorldEvents.UNLOAD.register(CommonEvents::onUnloadWorld);
 		ServerPlayConnectionEvents.DISCONNECT.register(CommonEvents::playerLoggedOut);
 		AttackEntityCallback.EVENT.register(CommonEvents::onEntityAttackedByPlayer);
 		CommandRegistrationCallback.EVENT.register(CommonEvents::registerCommands);

--- a/src/main/java/com/simibubi/create/foundation/utility/WorldAttached.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/WorldAttached.java
@@ -2,9 +2,9 @@ package com.simibubi.create.foundation.utility;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -24,7 +24,9 @@ public class WorldAttached<T> {
 
 	public WorldAttached(Function<LevelAccessor, T> factory) {
 		this.factory = factory;
-		attached = new HashMap<>();
+		// Weak key hashmaps prevent worlds not existing anywhere else from leaking memory.
+		// This is only a fallback in the event that unload events fail to fire for any reason.
+		attached = new WeakHashMap<>();
 		allMaps.add(new WeakReference<>(attached));
 	}
 


### PR DESCRIPTION
This adds in 2 events to ensure that the ClientLevel is processed as expected, along with adding a fallback with a WeakHashMap to ensure that if the events are somehow missed that any worlds not referenced outside of Create aren't retained. The WeakHashMap patch could be ported upstream for as they could benefit in case of a misbehaving mod on Forge's side.

From quick testing, this resolves the issue and doesn't appear to have any side effects on the surface.

Fixes #635