### PR TITLE
Change datagen to use common tag names

### DIFF
--- a/src/main/java/com/simibubi/create/AllItems.java
+++ b/src/main/java/com/simibubi/create/AllItems.java
@@ -158,7 +158,7 @@ public class AllItems {
 		.register();
 
 	public static final ItemEntry<Item> RAW_ZINC =
-		taggedIngredient("raw_zinc", forgeItemTag("zinc_raw_materials"), TagKey.create(Registry.ITEM_REGISTRY, new ResourceLocation("c", "raw_materials")));
+		taggedIngredient("raw_zinc", forgeItemTag("raw_zinc_ores"), TagKey.create(Registry.ITEM_REGISTRY, new ResourceLocation("c", "raw_ores")));
 
 	public static final ItemEntry<Item> ANDESITE_ALLOY = taggedIngredient("andesite_alloy", CREATE_INGOTS.tag),
 		ZINC_INGOT = taggedIngredient("zinc_ingot", forgeItemTag("zinc_ingots"), CREATE_INGOTS.tag),


### PR DESCRIPTION
This PR is a simple 1-line fix to datagen, which fixes a few tag names from a Forge tag amalgamation to what most mods out there use for common tags.

Zinc Raw Materials -> Raw Zinc Ores
Raw Materials -> Raw Ores 