### PR TITLE
Updated the modded_stripped_logs.json and modded_stripped_wood.json 

### DIFF
--- a/src/generated/resources/data/create/tags/items/modded_stripped_logs.json
+++ b/src/generated/resources/data/create/tags/items/modded_stripped_logs.json
@@ -292,6 +292,50 @@
     {
       "id": "byg:stripped_bulbis_stem",
       "required": false
+    },
+    {
+      "id": "terrestria:stripped_cypress_log",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_hemlock_log",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_japanese_maple_log",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_rainbow_eucalyptus_log",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_redwood_log",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_rubber_log",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_sakura_log",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_small_oak_log",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_willow_log",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_yucca_palm_log",
+      "required": false
+    },
+    {
+      "id": "traverse:stripped_fir_log",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/create/tags/items/modded_stripped_logs.json
+++ b/src/generated/resources/data/create/tags/items/modded_stripped_logs.json
@@ -336,6 +336,14 @@
     {
       "id": "traverse:stripped_fir_log",
       "required": false
+    },
+    {
+      "id":"cinderscapes:stripped_umbral_stem",
+      "required": false
+    },
+    {
+      "id":"cinderscapes:stripped_scorched_stem",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/create/tags/items/modded_stripped_wood.json
+++ b/src/generated/resources/data/create/tags/items/modded_stripped_wood.json
@@ -294,6 +294,10 @@
       "required": false
     },
     {
+      "id": "traverse:stripped_fir_wood",
+      "required": false
+    },
+    {
       "id": "terrestria:stripped_cypress_wood",
       "required": false
     },
@@ -334,8 +338,21 @@
       "required": false
     },
     {
-      "id": "traverse:stripped_fir_wood",
+      "id":"cinderscapes:stripped_umbral_hyphae",
+      "required": false
+    },
+    {
+      "id":"cinderscapes:stripped_umbral_stem",
+      "required": false
+    },
+    {
+      "id":"cinderscapes:stripped_scorched_hyphae",
+      "required": false
+    },
+    {
+      "id":"cinderscapes:stripped_scorched_stem",
       "required": false
     }
+
   ]
 }

--- a/src/generated/resources/data/create/tags/items/modded_stripped_wood.json
+++ b/src/generated/resources/data/create/tags/items/modded_stripped_wood.json
@@ -292,6 +292,50 @@
     {
       "id": "byg:stripped_bulbis_wood",
       "required": false
+    },
+    {
+      "id": "terrestria:stripped_cypress_wood",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_hemlock_wood",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_japanese_maple_wood",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_rainbow_eucalyptus_wood",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_redwood_wood",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_rubber_wood",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_sakura_wood",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_small_oak_wood",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_willow_wood",
+      "required": false
+    },
+    {
+      "id": "terrestria:stripped_yucca_palm_wood",
+      "required": false
+    },
+    {
+      "id": "traverse:stripped_fir_wood",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/create/tags/items/modded_stripped_wood.json
+++ b/src/generated/resources/data/create/tags/items/modded_stripped_wood.json
@@ -342,17 +342,8 @@
       "required": false
     },
     {
-      "id":"cinderscapes:stripped_umbral_stem",
-      "required": false
-    },
-    {
       "id":"cinderscapes:stripped_scorched_hyphae",
       "required": false
-    },
-    {
-      "id":"cinderscapes:stripped_scorched_stem",
-      "required": false
     }
-
   ]
 }


### PR DESCRIPTION
Added support for wood types added by traverse, terrestria, and cinderscapes. Not much to it, followed existing conventions as far as i know. 