### PR TITLE
Remove fakeconfig[toml] due to failed builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,9 +92,6 @@ def setup(DependencyHandler deps) {
 def devEnv(DependencyHandler deps) {
     deps.modLocalRuntime("maven.modrinth:lazydfu:0.1.3")
     deps.modLocalRuntime("maven.modrinth:lithium:mc1.19.2-0.10.0")
-    // used to prevent forge config api port from complaining
-    deps.modImplementation("com.github.AlphaMode:fakeconfig:master-SNAPSHOT") { exclude(group: "net.fabricmc.fabric-api") }
-    deps.modImplementation("com.github.AlphaMode:fakeconfigtoml:master-SNAPSHOT") { exclude(group: "net.fabricmc.fabric-api") }
 }
 
 // setup mods that are available for compatibility reasons


### PR DESCRIPTION
fakeconfig[toml] causes builds to fail majority of the time, so far 100% of the time on github build jobs even when using the latest listing on jitpack
```
> Could not resolve all dependencies for configuration ':modImplementation'.
   > Could not find com.github.AlphaMode:fakeconfigtoml:master-SNAPSHOT.
```
Removing this dependency solves the failed builds.