### PR TITLE
Fix Display Link not showing correct item counts

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/item/CountedItemStackList.java
+++ b/src/main/java/com/simibubi/create/foundation/item/CountedItemStackList.java
@@ -27,8 +27,12 @@ public class CountedItemStackList {
 	public CountedItemStackList(Storage<ItemVariant> inventory, FilteringBehaviour filteringBehaviour) {
 		try (Transaction t = TransferUtil.getTransaction()){
 			for (StorageView<ItemVariant> view : inventory.iterable(t)) {
-				if (filteringBehaviour.test(view.getResource().toStack()))
-					add(view.getResource().toStack(ItemHelper.truncateLong(view.getAmount())));
+				if (view.isResourceBlank())
+					continue;
+				if (!filteringBehaviour.test(view.getResource().toStack()))
+					continue;
+				int count = ItemHelper.truncateLong(view.extract(view.getResource(), view.getAmount(), t));
+				add(view.getResource().toStack(), count);
 			}
 		}
 	}


### PR DESCRIPTION
I changed the `CountedItemStackList` constructor to use `view.extract()`, similarly to what TropheusJ did in 0e71930cfc96e900bd8b4bf8798e4a7b3c8b79bb.

Am I targeting the right branch or even repo?

Resolves #769