### PR TITLE
Fix Emeraldite Ore Recipe

### DIFF
--- a/src/main/resources/data/create/recipes/compat/byg/crushing/emeraldite_ore.json
+++ b/src/main/resources/data/create/recipes/compat/byg/crushing/emeraldite_ore.json
@@ -10,7 +10,7 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "tag": "forge:ores/emeraldite"
+      "tag": "c:emeraldite_ores"
     }
   ],
   "results": [


### PR DESCRIPTION
Recipe used forge tag which doesn't exist in fabric.