### PR TITLE
Attempt to continue sequenced assembly recipe before starting new one

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/itemAssembly/SequencedAssemblyRecipe.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/itemAssembly/SequencedAssemblyRecipe.java
@@ -147,8 +147,6 @@ public class SequencedAssemblyRecipe implements Recipe<Container> {
 	}
 
 	private boolean appliesTo(ItemStack input) {
-		if (ingredient.test(input))
-			return true;
 		if (input.hasTag()) {
 			if (getTransitionalItem().getItem() == input.getItem()) {
 				if (input.getTag().contains("SequencedAssembly")) {
@@ -158,6 +156,8 @@ public class SequencedAssemblyRecipe implements Recipe<Container> {
 				}
 			}
 		}
+		if (ingredient.test(input))
+			return true;
 		return false;
 	}
 


### PR DESCRIPTION
When checking to see if a sequenced assembly recipe applies to an item, `appliesTo` checks to see if a new recipe can be started before checking to see if a partially completed recipe should be continued. In the event that the transitional item of a sequenced assembly recipe is the starting item for another sequenced assembly recipe, this can cause unexpected behavior. This pull request switches the order of the checks.