### PR TITLE
Changed from Mangrove to White_Mangrove

### DIFF
--- a/src/generated/resources/data/create/recipes/cutting/compat/byg/stripped_white_mangrove_log.json
+++ b/src/generated/resources/data/create/recipes/cutting/compat/byg/stripped_white_mangrove_log.json
@@ -10,13 +10,14 @@
   ],
   "ingredients": [
     {
-      "item": "byg:white_mangrove_wood"
+      "item": "byg:stripped_white_mangrove_log"
     }
   ],
   "processingTime": 50,
   "results": [
     {
-      "item": "byg:stripped_white_mangrove_wood"
+      "count": 6,
+      "item": "byg:white_mangrove_planks"
     }
   ]
 }

--- a/src/generated/resources/data/create/recipes/cutting/compat/byg/stripped_white_mangrove_wood.json
+++ b/src/generated/resources/data/create/recipes/cutting/compat/byg/stripped_white_mangrove_wood.json
@@ -10,13 +10,14 @@
   ],
   "ingredients": [
     {
-      "item": "byg:white_mangrove_wood"
+      "item": "byg:stripped_white_mangrove_wood"
     }
   ],
   "processingTime": 50,
   "results": [
     {
-      "item": "byg:stripped_white_mangrove_wood"
+      "count": 6,
+      "item": "byg:white_mangrove_planks"
     }
   ]
 }

--- a/src/generated/resources/data/create/recipes/cutting/compat/byg/white_mangrove_log.json
+++ b/src/generated/resources/data/create/recipes/cutting/compat/byg/white_mangrove_log.json
@@ -10,13 +10,13 @@
   ],
   "ingredients": [
     {
-      "item": "byg:white_mangrove_wood"
+      "item": "byg:white_mangrove_log"
     }
   ],
   "processingTime": 50,
   "results": [
     {
-      "item": "byg:stripped_white_mangrove_wood"
+      "item": "byg:stripped_white_mangrove_log"
     }
   ]
 }

--- a/src/generated/resources/data/create/recipes/cutting/compat/byg/white_mangrove_wood.json
+++ b/src/generated/resources/data/create/recipes/cutting/compat/byg/white_mangrove_wood.json
@@ -1,0 +1,22 @@
+{
+  "type": "create:cutting",
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "byg"
+      ]
+    }
+  ],
+  "ingredients": [
+    {
+      "item": "byg:white_mangrove_wood"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "item": "byg:stripped_white_mangrove_wood"
+    }
+  ]
+}


### PR DESCRIPTION
Changed in 1.19  the recipe error for mangrove. 

mangrove was changed in byg to white_mangrove, this files fix the errors in console logs