### PR TITLE
CC-Tweaked compatibility in mc1.20.1/fabric/dev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ def devEnv(DependencyHandler deps) {
     deps.modLocalRuntime("dev.onyxstudios.cardinal-components-api:cardinal-components-base:$cca_version")
     deps.modLocalRuntime("dev.onyxstudios.cardinal-components-api:cardinal-components-entity:$cca_version")
     if (Boolean.valueOf(cc_enabled)) {
-        deps.modLocalRuntime("maven.modrinth:cc-restitched:$cc_version")
+        deps.modLocalRuntime("cc.tweaked:cc-tweaked-$minecraft_version-fabric:$cc_version")
         deps.modLocalRuntime("maven.modrinth:cloth-config:$cloth_version")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ repositories {
     maven { url = "https://maven.shedaniel.me/" } // REI and deps
     maven { url = "https://api.modrinth.com/maven" } // LazyDFU, Sodium, Sandwichable
     maven { url = "https://maven.terraformersmc.com/" } // Mod Menu, Trinkets
+    maven { url = "https://squiddev.cc/maven" } // CC:T
     maven { url = "https://modmaven.dev" } // Botania
     maven { // Reach Entity Attributes
         url = "https://maven.jamieswhiteshirt.com/libs-release"
@@ -101,7 +102,7 @@ def devEnv(DependencyHandler deps) {
 
 // setup mods that are available for compatibility reasons
 def compat(DependencyHandler deps) {
-    deps.modCompileOnly("maven.modrinth:cc-restitched:$cc_version")
+    deps.modCompileOnly("cc.tweaked:cc-tweaked-$minecraft_version-fabric-api:$cc_version")
 
     deps.modCompileOnly("vazkii.botania:Botania:$botania_version") { transitive = false }
     deps.modCompileOnly("com.terraformersmc:modmenu:$modmenu_version")

--- a/gradle.properties
+++ b/gradle.properties
@@ -65,7 +65,7 @@ trinkets_version = 3.7.0
 # for Trinkets - https://modrinth.com/mod/cardinal-components-api/versions
 cca_version = 5.2.1
 
-# Whether CC: Restitched should be enabled in dev or not
+# Whether CC: Tweaked should be enabled in dev or not
 cc_enabled = false
 # What recipe viewer to use ('emi', 'rei', or 'jei'. if you change it, don't push it)
 recipe_viewer = emi

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ jsr305_version = 3.0.2
 
 # Compat
 # https://modrinth.com/mod/cc-restitched/versions
-cc_version = 1.101.2+1.19.1
+cc_version = 1.106.1
 # for CC - https://modrinth.com/mod/cloth-config/versions
 cloth_version = 11.1.106+fabric
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ night_config_version = 3.6.3
 jsr305_version = 3.0.2
 
 # Compat
-# https://modrinth.com/mod/cc-restitched/versions
+# https://modrinth.com/mod/cc-tweaked/versions
 cc_version = 1.106.1
 # for CC - https://modrinth.com/mod/cloth-config/versions
 cloth_version = 11.1.106+fabric

--- a/src/main/java/com/simibubi/create/compat/computercraft/ComputerCraftProxy.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/ComputerCraftProxy.java
@@ -6,7 +6,9 @@ import com.simibubi.create.compat.Mods;
 import com.simibubi.create.compat.computercraft.implementation.ComputerBehaviour;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 
-import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.peripheral.PeripheralLookup;
+
+import static com.simibubi.create.compat.computercraft.implementation.ComputerBehaviour.peripheralProvider;
 
 public class ComputerCraftProxy {
 
@@ -19,7 +21,7 @@ public class ComputerCraftProxy {
 		/* Comment if computercraft.implementation is not in the source set */
 		computerFactory = ComputerBehaviour::new;
 
-		ComputerCraftAPI.registerPeripheralProvider(ComputerBehaviour.PERIPHERAL_PROVIDER);
+		PeripheralLookup.get().registerFallback((level, blockPos, blockState, blockEntity, direction) -> peripheralProvider(level, blockPos));
 	}
 
 	private static Function<SmartBlockEntity, ? extends AbstractComputerBehaviour> fallbackFactory;

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
@@ -17,17 +17,21 @@ import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 
 import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.api.peripheral.IPeripheralProvider;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.Level;
+
+import org.jetbrains.annotations.Nullable;
 
 public class ComputerBehaviour extends AbstractComputerBehaviour {
 
-	public static final IPeripheralProvider PERIPHERAL_PROVIDER = (level, blockPos, direction) -> {
+	@Nullable
+	public static IPeripheral peripheralProvider(Level level, BlockPos blockPos) {
 		AbstractComputerBehaviour behavior = BlockEntityBehaviour.get(level, blockPos, AbstractComputerBehaviour.TYPE);
 		if (behavior instanceof ComputerBehaviour real)
-			return real.peripheral;
+			return real.getPeripheral();
 		return null;
-	};
+	}
 
 	IPeripheral peripheral;
 


### PR DESCRIPTION
I noticed that Create crashes whenever the mod `cc-tweaked` was installed as well.
Create-fabric previously was made compatible for CC:R v1.102.6 _(or something similar)_, which is much older than the latest version we have in CC:T now. Some stuff changed within time, including how peripherals are registered, which is why the game now crashes.

Therefore, I adjusted the code to work within the latest version of ComputerCraft _(`cc-tweaked`)_, instead of `cc-restitched` for **mc1.20.1**

I kept the changes as minimal as possible and it _(hopefully)_ should work without any issues.

> TL;DR
![tl-dr](https://github.com/Creators-of-Create/Create/assets/53350357/30a31175-3a6b-42fc-aa95-0d5b8ff26853)
