### PR TITLE
Sodium 0.5.x is now under conflicts instead of breaks

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -73,7 +73,9 @@
   "breaks": {
     "optifabric": "*",
     "colormatic": "<=3.1.1",
-    "iris": "<=1.2.5",
+    "iris": "<=1.2.5"
+  },
+  "conflicts": {
     "sodium": ">=0.5.0"
   },
 


### PR DESCRIPTION
The reasoning is so painfully dumb that I needed to open a PR for this literal two-line change.

In short, Sodium 0.5.x will no longer stop you from booting, but you'll be warned about a potential conflict in the log file.

This is to undo the damage of another commit that wrongly added it to breaks, meaning it stopped you from booting unless you extracted, edited, and reinserted this file. (You shouldn't have to edit a mod's jar file to make it work properly)