### PR TITLE
Fix Create breaks on having Sodium 1.20.1

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -74,7 +74,7 @@
     "optifabric": "*",
     "colormatic": "<=3.1.1",
     "iris": "<=1.2.5",
-    "sodium": ">=0.5.0"
+    "sodium": "<=0.5.0"
   },
 
   "custom": {


### PR DESCRIPTION
I guess, it was a typo and devs didn't noticed it as they had a lot of work, when I started the game, it crashed cuz of this.