### PR TITLE
[mc1.20.1] Update Sodium restraint to <6.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs = -Xmx4G
 # check these on https://fabricmc.net/develop/
 minecraft_version = 1.20.1
 loader_version = 0.14.21
-fabric_version = 0.89.3+1.20.1
+fabric_version = 0.89.0+1.20.1
 
 # Mod Properties
 mod_version = 0.6.0-a

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,10 @@ org.gradle.jvmargs = -Xmx4G
 # check these on https://fabricmc.net/develop/
 minecraft_version = 1.20.1
 loader_version = 0.14.21
-fabric_version = 0.86.0+1.20.1
+fabric_version = 0.89.3+1.20.1
 
 # Mod Properties
-mod_version = 0.5.1-d
+mod_version = 0.6.0-a
 maven_group = com.simibubi.create
 
 # Dependencies
@@ -59,7 +59,7 @@ modmenu_version = 7.1.0
 # https://modrinth.com/mod/sandwichable/versions
 sandwichable_version = 1.3.1+1.20.1
 # https://modrinth.com/mod/sodium
-sodium_version = mc1.20-0.4.10
+sodium_version = mc1.20.1-0.5.3
 # https://github.com/emilyploszaj/trinkets/releases/
 trinkets_version = 3.7.0
 # for Trinkets - https://modrinth.com/mod/cardinal-components-api/versions

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -74,7 +74,7 @@
     "optifabric": "*",
     "colormatic": "<=3.1.1",
     "iris": "<=1.2.5",
-    "sodium": ">=0.5.0"
+    "sodium": ">=0.6.0"
   },
 
   "custom": {


### PR DESCRIPTION
Sodium 5.0.0 did not change how `markSpriteActive` works so we should be safe to run against `Sodium < 6.0.0`

* Update Sodium restraint to <6.0.0
* Update fabric dev version to 0.89.0 (To test using Indium 1.0.27)