### PR TITLE
Item Vault CC Tweaked compatability

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/vault/ItemVaultBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/vault/ItemVaultBlockEntity.java
@@ -13,7 +13,7 @@ import com.simibubi.create.infrastructure.config.AllConfigs;
 import io.github.fabricators_of_create.porting_lib.transfer.item.ItemStackHandler;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.base.CombinedStorage;
+import net.fabricmc.fabric.api.transfer.v1.storage.base.CombinedSlottedStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SidedStorageBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -265,7 +265,7 @@ public class ItemVaultBlockEntity extends SmartBlockEntity implements IMultiBloc
 			}
 		}
 
-		CombinedStorage<ItemVariant, ItemStackHandler> combinedInvWrapper = new CombinedStorage<>(List.of(invs));
+		CombinedSlottedStorage<ItemVariant, ItemStackHandler> combinedInvWrapper = new CombinedSlottedStorage<>(List.of(invs));
 		itemCapability = combinedInvWrapper;
 	}
 


### PR DESCRIPTION
I noticed a slight incompatibility with CC Tweaked (Computercraft). When I try to access vault inventories using the Lua API it provides, it doesn't show up (while it did for the forge version).

This was caused by the vault storage not being exposed as slotted storage. Because the ComputerCraft API is based on slots, it requires slotted storage.

As the underlying individual storage containers of the vault are already declared as `SlottedStorage`, it is an easy fix to also expose it as `CombinedSlottedStorage`.