### PR TITLE
Fix REI compat: Display recipes for items not in primary output

### DIFF
--- a/src/main/java/com/simibubi/create/compat/rei/display/CreateDisplay.java
+++ b/src/main/java/com/simibubi/create/compat/rei/display/CreateDisplay.java
@@ -2,11 +2,16 @@ package com.simibubi.create.compat.rei.display;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import com.simibubi.create.content.processing.recipe.ProcessingOutput;
+import com.simibubi.create.content.processing.recipe.ProcessingRecipe;
 
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 
 public class CreateDisplay<R extends Recipe<?>> implements Display {
@@ -23,8 +28,21 @@ public class CreateDisplay<R extends Recipe<?>> implements Display {
 	}
 
 	public CreateDisplay(R recipe, CategoryIdentifier<CreateDisplay<R>> id) {
-		this(recipe, id, EntryIngredients.ofIngredients(recipe.getIngredients()), Collections.singletonList(EntryIngredients.of(recipe.getResultItem())));
+		this.uid = id;
+		this.recipe = recipe;
+	
+		this.input = EntryIngredients.ofIngredients(recipe.getIngredients());
+	
+		if (recipe instanceof ProcessingRecipe) {
+			this.output = ((List<ItemStack>)((ProcessingRecipe) recipe).getRollableResultsAsItemStacks()).stream()
+				.map(EntryIngredients::of)
+				.collect(Collectors.toList());
+		} else {
+			this.output = Collections.singletonList(EntryIngredients.of(recipe.getResultItem()));
+		}
 	}
+	
+
 
 	public R getRecipe() {
 		return recipe;


### PR DESCRIPTION
## Overview:
Fixed an issue where recipes with the searched item as a secondary (or later) output were not displayed in REI.

## Changes:
- Modified `CreateDisplay` to account for recipes with multiple outputs.
- Improved REI integration to show recipes even if the searched item isn't the primary output.

## Impact:
Players can now search for recipes where the requested item is a 2nd, 3rd, 4th, ... output, enhancing the recipe discovery experience.

## Testing:
Test with "Redstone Dust", which is a secondary output of the Bulk Washing "Crushed Raw Iron" recipe. Before the fix, this recipe wouldn't appear when searching for recipes of "Redstone Dust".
