### PR TITLE
fix entity position fields not being used

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/OrientedContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/OrientedContraptionEntity.java
@@ -71,12 +71,7 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 	private boolean attachedExtraInventories;
 	private boolean manuallyPlaced;
 
-	public float prevYaw;
-	public float yaw;
 	public float targetYaw;
-
-	public float prevPitch;
-	public float pitch;
 
 	public int nonDamageTicks;
 
@@ -134,11 +129,11 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 		ContraptionRotationState crs = new ContraptionRotationState();
 
 		float yawOffset = getYawOffset();
-		crs.zRotation = pitch;
-		crs.yRotation = -yaw + yawOffset;
+		crs.zRotation = getXRot();
+		crs.yRotation = -getYRot() + yawOffset;
 
-		if (pitch != 0 && yaw != 0) {
-			crs.secondYRotation = -yaw;
+		if (getXRot() != 0 && getYRot() != 0) {
+			crs.secondYRotation = -getYRot();
 			crs.yRotation = yawOffset;
 		}
 
@@ -164,8 +159,8 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 		if (compound.contains("InitialOrientation"))
 			setInitialOrientation(NBTHelper.readEnum(compound, "InitialOrientation", Direction.class));
 
-		yaw = compound.getFloat("Yaw");
-		pitch = compound.getFloat("Pitch");
+		setYRot(compound.getFloat("Yaw"));
+		setXRot(compound.getFloat("Pitch"));
 		manuallyPlaced = compound.getBoolean("Placed");
 
 		if (compound.contains("ForceYaw"))
@@ -174,8 +169,10 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 		ListTag vecNBT = compound.getList("CachedMotion", 6);
 		if (!vecNBT.isEmpty()) {
 			motionBeforeStall = new Vec3(vecNBT.getDouble(0), vecNBT.getDouble(1), vecNBT.getDouble(2));
-			if (!motionBeforeStall.equals(Vec3.ZERO))
-				targetYaw = prevYaw = yaw += yawFromVector(motionBeforeStall);
+			if (!motionBeforeStall.equals(Vec3.ZERO)) {
+				setYRot(getYRot() + yawFromVector(motionBeforeStall));
+				targetYaw = yRotO = getYRot();
+			}
 			setDeltaMovement(Vec3.ZERO);
 		}
 
@@ -194,13 +191,13 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 			.isHorizontal())
 			NBTHelper.writeEnum(compound, "InitialOrientation", optional);
 		if (forceAngle) {
-			compound.putFloat("ForceYaw", yaw);
+			compound.putFloat("ForceYaw", getYRot());
 			forceAngle = false;
 		}
 
 		compound.putBoolean("Placed", manuallyPlaced);
-		compound.putFloat("Yaw", yaw);
-		compound.putFloat("Pitch", pitch);
+		compound.putFloat("Yaw", getYRot());
+		compound.putFloat("Pitch", getXRot());
 
 		if (getCouplingId() != null)
 			compound.putUUID("OnCoupling", getCouplingId());
@@ -224,7 +221,8 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 	}
 
 	public void startAtYaw(float yaw) {
-		targetYaw = this.yaw = prevYaw = yaw;
+		setYRot(yaw);
+		targetYaw = yRotO = yaw;
 		forceAngle = true;
 	}
 
@@ -245,11 +243,11 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 	}
 
 	public float getViewYRot(float partialTicks) {
-		return -(partialTicks == 1.0F ? yaw : angleLerp(partialTicks, prevYaw, yaw));
+		return -(partialTicks == 1.0F ? getYRot() : angleLerp(partialTicks, yRotO, getYRot()));
 	}
 
 	public float getViewXRot(float partialTicks) {
-		return partialTicks == 1.0F ? pitch : angleLerp(partialTicks, prevPitch, pitch);
+		return partialTicks == 1.0F ? getXRot() : angleLerp(partialTicks, xRotO, getXRot());
 	}
 
 	@Override
@@ -323,6 +321,7 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 		}
 	}
 
+	// TODO: find why the previous tick values are staying in sync with the current ones
 	protected boolean updateOrientation(boolean rotationLock, boolean wasStalled, Entity riding, boolean isOnCoupling) {
 		if (isOnCoupling) {
 			Couple<MinecartController> coupledCarts = getCoupledCartsIfPresent();
@@ -340,14 +339,14 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 			double diffY = positionVec.y - coupledVec.y;
 			double diffZ = positionVec.z - coupledVec.z;
 
-			prevYaw = yaw;
-			prevPitch = pitch;
-			yaw = (float) (Mth.atan2(diffZ, diffX) * 180 / Math.PI);
-			pitch = (float) (Math.atan2(diffY, Math.sqrt(diffX * diffX + diffZ * diffZ)) * 180 / Math.PI);
+			yRotO = getYRot();
+			xRotO = getXRot();
+			setYRot((float) (Mth.atan2(diffZ, diffX) * 180 / Math.PI));
+			setXRot((float) (Math.atan2(diffY, Math.sqrt(diffX * diffX + diffZ * diffZ)) * 180 / Math.PI));
 
 			if (getCouplingId().equals(riding.getUUID())) {
-				pitch *= -1;
-				yaw += 180;
+				setXRot(getXRot() * -1);
+				setYRot(getYRot() + 180);
 			}
 			return false;
 		}
@@ -361,12 +360,12 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 				.isVertical())
 				return false;
 			OrientedContraptionEntity parent = (OrientedContraptionEntity) riding;
-			prevYaw = yaw;
-			yaw = -parent.getViewYRot(1);
+			yRotO = getYRot();
+			setYRot(-parent.getViewYRot(1));
 			return false;
 		}
 
-		prevYaw = yaw;
+		yRotO = getYRot();
 		if (wasStalled)
 			return false;
 
@@ -395,18 +394,18 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 				targetYaw = yawFromVector(motion);
 				if (targetYaw < 0)
 					targetYaw += 360;
-				if (yaw < 0)
-					yaw += 360;
+				if (getYRot() < 0)
+					setYRot(getYRot() + 360);
 			}
 
-			prevYaw = yaw;
+			yRotO = getYRot();
 			float maxApproachSpeed = (float) (motion.length() * 12f / (Math.max(1, getBoundingBox().getXsize() / 6f)));
-			float yawHint = AngleHelper.getShortestAngleDiff(yaw, yawFromVector(locationDiff));
-			float approach = AngleHelper.getShortestAngleDiff(yaw, targetYaw, yawHint);
+			float yawHint = AngleHelper.getShortestAngleDiff(getYRot(), yawFromVector(locationDiff));
+			float approach = AngleHelper.getShortestAngleDiff(getYRot(), targetYaw, yawHint);
 			approach = Mth.clamp(approach, -maxApproachSpeed, maxApproachSpeed);
-			yaw += approach;
-			if (Math.abs(AngleHelper.getShortestAngleDiff(yaw, targetYaw)) < 1f)
-				yaw = targetYaw;
+			setYRot(getYRot() + approach);
+			if (Math.abs(AngleHelper.getShortestAngleDiff(getYRot(), targetYaw)) < 1f)
+				setYRot(targetYaw);
 			else
 				rotating = true;
 		}
@@ -515,17 +514,17 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 	@Override
 	protected StructureTransform makeStructureTransform() {
 		BlockPos offset = BlockPos.containing(getAnchorVec().add(.5, .5, .5));
-		return new StructureTransform(offset, 0, -yaw + getInitialYaw(), 0);
+		return new StructureTransform(offset, 0, -getYRot() + getInitialYaw(), 0);
 	}
 
 	@Override
 	protected float getStalledAngle() {
-		return yaw;
+		return getYRot();
 	}
 
 	@Override
 	protected void handleStallInformation(double x, double y, double z, float angle) {
-		yaw = angle;
+		setYRot(angle);
 	}
 
 	@Override
@@ -580,7 +579,7 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 		Vec3 passengerPosition = parent.getPassengerPosition(this, partialTicks);
 		if (passengerPosition == null)
 			return Vec3.ZERO;
-		
+
 		double x = passengerPosition.x - Mth.lerp(partialTicks, this.xOld, this.getX());
 		double y = passengerPosition.y - Mth.lerp(partialTicks, this.yOld, this.getY());
 		double z = passengerPosition.z - Mth.lerp(partialTicks, this.zOld, this.getZ());

--- a/src/main/java/com/simibubi/create/content/contraptions/mounted/CartAssemblerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/mounted/CartAssemblerBlockEntity.java
@@ -188,8 +188,8 @@ public class CartAssemblerBlockEntity extends SmartBlockEntity implements IDispl
 		UUID couplingId = contraption.getCouplingId();
 
 		if (couplingId == null) {
-			contraption.yaw = CartAssemblerBlock.getHorizontalDirection(getBlockState())
-				.toYRot();
+			contraption.setYRot(CartAssemblerBlock.getHorizontalDirection(getBlockState())
+				.toYRot());
 			disassembleCart(cart);
 			return;
 		}

--- a/src/main/java/com/simibubi/create/content/trains/TrainHUD.java
+++ b/src/main/java/com/simibubi/create/content/trains/TrainHUD.java
@@ -190,7 +190,7 @@ public class TrainHUD {
 			angleOffset *= -1;
 
 		float snapSize = 22.5f;
-		float diff = AngleHelper.getShortestAngleDiff(cameraEntity.getYRot(), cce.yaw) + (inverted ? -90 : 90);
+		float diff = AngleHelper.getShortestAngleDiff(cameraEntity.getYRot(), cce.getYRot()) + (inverted ? -90 : 90);
 		if (Math.abs(diff) < 60)
 			diff = 0;
 

--- a/src/main/java/com/simibubi/create/content/trains/entity/Carriage.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Carriage.java
@@ -851,8 +851,8 @@ public class Carriage {
 			double diffY = positionVec.y - coupledVec.y;
 			double diffZ = positionVec.z - coupledVec.z;
 
-			entity.prevYaw = entity.yaw;
-			entity.prevPitch = entity.pitch;
+			entity.yRotO = entity.getYRot();
+			entity.xRotO = entity.getXRot();
 
 			if (!entity.level().isClientSide()) {
 				Vec3 lookahead = positionAnchor.add(positionAnchor.subtract(entity.position())
@@ -883,8 +883,8 @@ public class Carriage {
 			}
 
 			entity.setPos(positionAnchor);
-			entity.yaw = (float) (Mth.atan2(diffZ, diffX) * 180 / Math.PI) + 180;
-			entity.pitch = (float) (Math.atan2(diffY, Math.sqrt(diffX * diffX + diffZ * diffZ)) * 180 / Math.PI) * -1;
+			entity.setYRot((float) (Mth.atan2(diffZ, diffX) * 180 / Math.PI) + 180);
+			entity.setXRot((float) (Math.atan2(diffY, Math.sqrt(diffX * diffX + diffZ * diffZ)) * 180 / Math.PI) * -1);
 
 			if (!entity.firstPositionUpdate)
 				return;
@@ -892,8 +892,8 @@ public class Carriage {
 			entity.xo = entity.getX();
 			entity.yo = entity.getY();
 			entity.zo = entity.getZ();
-			entity.prevYaw = entity.yaw;
-			entity.prevPitch = entity.pitch;
+			entity.yRotO = entity.getYRot();
+			entity.xRotO = entity.getXRot();
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/content/trains/entity/CarriageBogey.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/CarriageBogey.java
@@ -94,10 +94,10 @@ public class CarriageBogey {
 		float yRot = 0;
 
 		if (leading().edge == null || carriage.train.derailed) {
-			yRot = -90 + entity.yaw - derailAngle;
+			yRot = -90 + entity.getYRot() - derailAngle;
 		} else if (!entity.level().dimension()
 				.equals(getDimension())) {
-			yRot = -90 + entity.yaw;
+			yRot = -90 + entity.getYRot();
 			xRot = 0;
 		} else {
 			Vec3 positionVec = leading().getPosition(carriage.train.graph);

--- a/src/main/java/com/simibubi/create/content/trains/entity/CarriageContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/CarriageContraptionEntity.java
@@ -312,7 +312,7 @@ public class CarriageContraptionEntity extends OrientedContraptionEntity {
 		double distanceTo = 0;
 		if (!firstPositionUpdate) {
 			Vec3 diff = position().subtract(xo, yo, zo);
-			Vec3 relativeDiff = VecHelper.rotate(diff, yaw, Axis.Y);
+			Vec3 relativeDiff = VecHelper.rotate(diff, getYRot(), Axis.Y);
 			double signum = Math.signum(-relativeDiff.x);
 			distanceTo = diff.length() * signum;
 			movingBackwards = signum < 0;
@@ -440,7 +440,7 @@ public class CarriageContraptionEntity extends OrientedContraptionEntity {
 			return;
 
 		boolean alongX = Mth.equal(pivot.x, Math.round(pivot.x));
-		int extraFlip = Direction.fromYRot(yaw)
+		int extraFlip = Direction.fromYRot(getYRot())
 			.getAxisDirection()
 			.getStep();
 

--- a/src/main/java/com/simibubi/create/content/trains/entity/Train.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Train.java
@@ -762,9 +762,9 @@ public class Train {
 			CarriageContraptionEntity entity = carriage.anyAvailableEntity();
 			if (entity == null)
 				return false;
-			if (!Mth.equal(entity.pitch, 0))
+			if (!Mth.equal(entity.getXRot(), 0))
 				return false;
-			if (!Mth.equal(((entity.yaw % 90) + 360) % 90, 0))
+			if (!Mth.equal(((entity.getYRot() % 90) + 360) % 90, 0))
 				return false;
 		}
 		return true;

--- a/src/main/java/com/simibubi/create/foundation/mixin/client/EntityContraptionInteractionMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/client/EntityContraptionInteractionMixin.java
@@ -5,6 +5,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.simibubi.create.content.contraptions.OrientedContraptionEntity;
+
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.logging.log4j.util.TriConsumer;
 import org.objectweb.asm.Opcodes;
@@ -14,6 +16,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.simibubi.create.content.contraptions.AbstractContraptionEntity;
@@ -168,5 +171,19 @@ public abstract class EntityContraptionInteractionMixin {
 				);
 			}
 		});
+	}
+
+	@Redirect(method = "baseTick", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/Entity;xRotO:F"))
+	private void create$contraptionSetsOwnXRotO(Entity instance, float xRotO) {
+        if (!(instance instanceof OrientedContraptionEntity)) {
+			instance.xRotO = xRotO;
+		}
+	}
+
+	@Redirect(method = "baseTick", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/Entity;yRotO:F"))
+	private void create$contraptionSetsOwnYRotO(Entity instance, float yRotO) {
+        if (!(instance instanceof OrientedContraptionEntity)) {
+			instance.yRotO = yRotO;
+		}
 	}
 }

--- a/src/main/java/com/simibubi/create/foundation/mixin/client/EntityContraptionInteractionMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/client/EntityContraptionInteractionMixin.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.simibubi.create.content.contraptions.OrientedContraptionEntity;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -16,7 +17,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.simibubi.create.content.contraptions.AbstractContraptionEntity;
@@ -173,17 +173,13 @@ public abstract class EntityContraptionInteractionMixin {
 		});
 	}
 
-	@Redirect(method = "baseTick", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/Entity;xRotO:F"))
-	private void create$contraptionSetsOwnXRotO(Entity instance, float xRotO) {
-        if (!(instance instanceof OrientedContraptionEntity)) {
-			instance.xRotO = xRotO;
-		}
+	@WrapWithCondition(method = "baseTick", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/Entity;xRotO:F"))
+	private boolean create$contraptionSetsOwnXRotO(Entity instance, float xRotO) {
+        return !(instance instanceof OrientedContraptionEntity);
 	}
 
-	@Redirect(method = "baseTick", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/Entity;yRotO:F"))
-	private void create$contraptionSetsOwnYRotO(Entity instance, float yRotO) {
-        if (!(instance instanceof OrientedContraptionEntity)) {
-			instance.yRotO = yRotO;
-		}
+	@WrapWithCondition(method = "baseTick", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/Entity;yRotO:F"))
+	private boolean create$contraptionSetsOwnYRotO(Entity instance, float yRotO) {
+		return !(instance instanceof OrientedContraptionEntity);
 	}
 }

--- a/src/main/java/com/simibubi/create/foundation/mixin/client/EntityContraptionInteractionMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/client/EntityContraptionInteractionMixin.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
 import com.simibubi.create.content.contraptions.OrientedContraptionEntity;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -173,6 +173,7 @@ public abstract class EntityContraptionInteractionMixin {
 		});
 	}
 
+	// using v1 for compatibility with earlier fabric loader releases
 	@WrapWithCondition(method = "baseTick", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/Entity;xRotO:F"))
 	private boolean create$contraptionSetsOwnXRotO(Entity instance, float xRotO) {
         return !(instance instanceof OrientedContraptionEntity);


### PR DESCRIPTION
maybe people depend on these fields, and if so this wouldn't make sense to merge...

otherwise, my mod requires vehicle yaw and pitch fields to be updated (https://github.com/tildejustin/minecart-turning/blob/466bc969bb3abd05e28ad582ceccf2b272258cdb/src/main/java/dev/tildejustin/minecartturning/mixin/EntityMixin.java#L48-L50). i'm not familiar with create at all, but someone asked for train compatibility and this seemed like the best way to go about that.
