### PR TITLE
Fix #1307

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
@@ -396,6 +396,8 @@ public abstract class Contraption {
 		for (Direction offset : Iterate.directions) {
 			BlockPos offsetPos = pos.relative(offset);
 			BlockState blockState = world.getBlockState(offsetPos);
+			if (isPistonHead(blockState))
+				continue;
 			if (isAnchoringBlockAt(offsetPos))
 				continue;
 			if (!movementAllowed(blockState, world, offsetPos)) {


### PR DESCRIPTION
During our multiplayer game I tried to build a tree farm and discovered a bug which I described in #1307 
When sticky piston is retracted and checks neighboring blocks, it also checks its own piston head block, which causes assembly error.
This commit fixes the bug for me although I'm not sure if there is a deeper underlying cause that I merely hid under this workaround.