### PR TITLE
fix issues #646 and #902 on mc1.18/fabric/dev branch

### DIFF
--- a/src/main/java/com/simibubi/create/compat/rei/category/CreateRecipeCategory.java
+++ b/src/main/java/com/simibubi/create/compat/rei/category/CreateRecipeCategory.java
@@ -127,10 +127,12 @@ public abstract class CreateRecipeCategory<T extends Recipe<?>> implements Displ
 		itemStacks.stream().filter(widget -> widget instanceof Slot).forEach(widget -> {
 			Slot slot = (Slot) widget;
 
+			int slotIndex = itemStacks.indexOf(widget);
+			
 			ClientEntryStacks.setTooltipProcessor(slot.getCurrentEntry(), (entryStack, tooltip) -> {
-//				if (slotIndex < startIndex)
-//					return;
-				ProcessingOutput output = results.get(/*slotIndex - startIndex*/0);
+				if (slotIndex < startIndex)
+					return;
+				ProcessingOutput output = results.get(slotIndex - startIndex);
 				float chance = output.getChance();
 				if (chance != 1)
 					tooltip.add(Lang.translateDirect("recipe.processing.chance", chance < 0.01 ? "<1" : (int) (chance * 100))


### PR DESCRIPTION
In addStochasticTooltip, chance should be retrieved from the corresponding output, not the first one.