### PR TITLE
Add null-safety check on usage of BlockEntity.loadStatic

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
@@ -288,10 +288,12 @@ public class BlockHelper {
 		if (data != null) {
 			if (existingBlockEntity instanceof IMergeableBE mergeable) {
 				BlockEntity loaded = BlockEntity.loadStatic(target, state, data);
-				if (existingBlockEntity.getType()
-					.equals(loaded.getType())) {
-					mergeable.accept(loaded);
-					return;
+				if (loaded != null) {
+					if (existingBlockEntity.getType()
+						.equals(loaded.getType())) {
+						mergeable.accept(loaded);
+						return;
+					}
 				}
 			}
 			BlockEntity blockEntity = world.getBlockEntity(target);


### PR DESCRIPTION
We had a schematicannon crash our server the other day, followed the logs, brought me here. Here we go. Happy to rebase for 1.18 and 1.20 too, as well as happy to upstream to forge versions if affected. lmk