### PR TITLE
Fixed crash due to null argument when deployer kills entity.

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
@@ -204,7 +204,7 @@ public class DeployerHandler {
 				success = true;
 			}
 
-			entity.captureDrops(null);
+			entity.captureDrops(new ArrayList<ItemEntity>());
 			capturedDrops.forEach(e -> player.getInventory()
 					.placeItemBackInInventory(e.getItem()));
 			if (success)


### PR DESCRIPTION
Fixed a crash when a deployer killed an entity. The crash was caused due to null argument in "captureDrops." Fixed by changing argument to empty ArrayList<ItemEntity>.