### PR TITLE
remove addStochasticTooltip bulk version

### DIFF
--- a/src/main/java/com/simibubi/create/compat/rei/category/BasinCategory.java
+++ b/src/main/java/com/simibubi/create/compat/rei/category/BasinCategory.java
@@ -12,6 +12,7 @@ import com.simibubi.create.compat.rei.display.CreateDisplay;
 import com.simibubi.create.content.processing.basin.BasinRecipe;
 import com.simibubi.create.content.processing.burner.BlazeBurnerBlock.HeatLevel;
 import com.simibubi.create.content.processing.recipe.HeatCondition;
+import com.simibubi.create.content.processing.recipe.ProcessingOutput;
 import com.simibubi.create.foundation.fluid.FluidIngredient;
 import com.simibubi.create.foundation.gui.AllGuiTextures;
 import com.simibubi.create.foundation.item.ItemHelper;
@@ -42,7 +43,7 @@ public class BasinCategory extends CreateRecipeCategory<BasinRecipe> {
 		BasinRecipe recipe = display.getRecipe();
 		NonNullList<FluidIngredient> fluidIngredients = recipe.getFluidIngredients();
 		List<Pair<Ingredient, MutableInt>> ingredients = ItemHelper.condenseIngredients(recipe.getIngredients());
-		List<ItemStack> itemOutputs = recipe.getRollableResultsAsItemStacks();
+		List<ProcessingOutput> itemOutputs = recipe.getRollableResults();
 		NonNullList<FluidStack> fluidOutputs = recipe.getFluidResults();
 
 		int size = ingredients.size() + fluidIngredients.size();
@@ -77,21 +78,20 @@ public class BasinCategory extends CreateRecipeCategory<BasinRecipe> {
 			widgets.add(fluidSlot);
 		}
 
-		int outSize = fluidOutputs.size() + recipe.getRollableResults()
-				.size();
+		int outSize = fluidOutputs.size() + itemOutputs.size();
 		int outputIndex = 0;
-
-		if (!itemOutputs.isEmpty())
-			addStochasticTooltip(widgets, recipe.getRollableResults(), i);
 
 		for (; outputIndex < outSize; outputIndex++) {
 			int xPosition = 141 - (outSize % 2 != 0 && outputIndex == outSize - 1 ? 0 : outputIndex % 2 == 0 ? 10 : -9);
 			int yPosition = -19 * (outputIndex / 2) + 50 + yOffset;
 
 			if (itemOutputs.size() > outputIndex) {
-				widgets.add(basicSlot(origin.x + xPosition + 1, origin.y + yPosition + yOffset + 1)
+				ProcessingOutput result = itemOutputs.get(outputIndex);
+				Slot outputSlot = basicSlot(origin.x + xPosition + 1, origin.y + yPosition + yOffset + 1)
 						.markOutput()
-						.entries(EntryIngredients.of(itemOutputs.get(outputIndex))));
+						.entries(EntryIngredients.of(result.getStack()));
+				widgets.add(outputSlot);
+				addStochasticTooltip(outputSlot, result);
 				i++;
 			} else {
 				Slot fluidSlot = basicSlot(origin.x + xPosition + 1, origin.y + yPosition + 1 + yOffset)

--- a/src/main/java/com/simibubi/create/compat/rei/category/CreateRecipeCategory.java
+++ b/src/main/java/com/simibubi/create/compat/rei/category/CreateRecipeCategory.java
@@ -143,6 +143,13 @@ public abstract class CreateRecipeCategory<T extends Recipe<?>> implements Displ
 		});
 	}
 
+	public static void addStochasticTooltip(Slot slot, ProcessingOutput output) {
+		ClientEntryStacks.setTooltipProcessor(slot.getCurrentEntry(), (entryStack, tooltip) -> {
+			addStochasticTooltip(output, tooltip);
+			return tooltip;
+		});
+	}
+
 	public static void addStochasticTooltip(ProcessingOutput output, Tooltip tooltip) {
 		float chance = output.getChance();
 		if (chance != 1)

--- a/src/main/java/com/simibubi/create/compat/rei/category/CreateRecipeCategory.java
+++ b/src/main/java/com/simibubi/create/compat/rei/category/CreateRecipeCategory.java
@@ -118,43 +118,14 @@ public abstract class CreateRecipeCategory<T extends Recipe<?>> implements Displ
 		return AllGuiTextures.JEI_CHANCE_SLOT;
 	}
 
-	public static void addStochasticTooltip(List<Widget> itemStacks, List<ProcessingOutput> results) {
-		addStochasticTooltip(itemStacks, results, 1);
-	}
-
-	public static void addStochasticTooltip(List<Widget> itemStacks, List<ProcessingOutput> results,
-											int startIndex) {
-		itemStacks.stream().filter(widget -> widget instanceof Slot).forEach(widget -> {
-			Slot slot = (Slot) widget;
-
-			int slotIndex = itemStacks.indexOf(widget);
-
-			ClientEntryStacks.setTooltipProcessor(slot.getCurrentEntry(), (entryStack, tooltip) -> {
-				int outputIndex = slotIndex - startIndex;
-				if (slotIndex < startIndex || outputIndex >= results.size())
-					return tooltip;
-				ProcessingOutput output = results.get(outputIndex);
-				float chance = output.getChance();
-				if (chance != 1)
-					tooltip.add(Lang.translateDirect("recipe.processing.chance", chance < 0.01 ? "<1" : (int) (chance * 100))
-							.withStyle(ChatFormatting.GOLD));
-				return tooltip;
-			});
-		});
-	}
-
 	public static void addStochasticTooltip(Slot slot, ProcessingOutput output) {
 		ClientEntryStacks.setTooltipProcessor(slot.getCurrentEntry(), (entryStack, tooltip) -> {
-			addStochasticTooltip(output, tooltip);
+			float chance = output.getChance();
+			if (chance != 1)
+				tooltip.add(Lang.translateDirect("recipe.processing.chance", chance < 0.01 ? "<1" : (int) (chance * 100))
+						.withStyle(ChatFormatting.GOLD));
 			return tooltip;
 		});
-	}
-
-	public static void addStochasticTooltip(ProcessingOutput output, Tooltip tooltip) {
-		float chance = output.getChance();
-		if (chance != 1)
-			tooltip.add(Lang.translateDirect("recipe.processing.chance", chance < 0.01 ? "<1" : (int) (chance * 100))
-					.withStyle(ChatFormatting.GOLD));
 	}
 
 	public static Slot basicSlot(int x, int y) {

--- a/src/main/java/com/simibubi/create/compat/rei/category/DeployingCategory.java
+++ b/src/main/java/com/simibubi/create/compat/rei/category/DeployingCategory.java
@@ -40,11 +40,13 @@ public class DeployingCategory extends CreateRecipeCategory<DeployerApplicationR
 		ingredients.add(basicSlot(origin.getX() + 51, origin.getY() + 5)
 				.markInput()
 				.entries(EntryIngredients.ofIngredient(recipe.getRequiredHeldItem())));
-		Slot output = basicSlot(origin.getX() + 132, origin.getY() + 51)
-				.markOutput()
-				.entries(EntryIngredients.of(recipe.getResultItem()));
-		ingredients.add(output);
-		addStochasticTooltip(ingredients, recipe.getRollableResults(), 2);
+		recipe.getRollableResults().stream().limit(1).forEach(result -> {
+			Slot outputSlot = basicSlot(origin.getX() + 132, origin.getY() + 51)
+					.markOutput()
+					.entries(EntryIngredients.of(result.getStack()));
+			ingredients.add(outputSlot);
+			addStochasticTooltip(outputSlot, result);
+		});
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/compat/rei/category/ItemApplicationCategory.java
+++ b/src/main/java/com/simibubi/create/compat/rei/category/ItemApplicationCategory.java
@@ -46,15 +46,13 @@ public class ItemApplicationCategory extends CreateRecipeCategory<ItemApplicatio
 		});
 		ingredients.add(slot);
 
-		Slot outputSlot = basicSlot(132, 38, origin)
-				.markOutput()
-				.entries(display.getOutputEntries().get(0));
-		ClientEntryStacks.setTooltipProcessor(outputSlot.getCurrentEntry(), (entryStack, tooltip) -> {
-					addStochasticTooltip(display.getRecipe().getRollableResults()
-							.get(0), tooltip);
-			return tooltip;
+		display.getRecipe().getRollableResults().stream().limit(1).forEach(result -> {
+			Slot outputSlot = basicSlot(132, 38, origin)
+					.markOutput()
+					.entries(EntryIngredients.of(result.getStack()));
+			ingredients.add(outputSlot);
+			addStochasticTooltip(outputSlot, result);
 		});
-		ingredients.add(outputSlot);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/compat/rei/category/PolishingCategory.java
+++ b/src/main/java/com/simibubi/create/compat/rei/category/PolishingCategory.java
@@ -12,6 +12,7 @@ import com.simibubi.create.foundation.gui.element.GuiGameElement;
 
 import io.github.fabricators_of_create.porting_lib.util.NBTSerializer;
 import me.shedaniel.math.Point;
+import me.shedaniel.rei.api.client.gui.widgets.Slot;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
 import net.minecraft.core.NonNullList;
@@ -30,16 +31,16 @@ public class PolishingCategory extends CreateRecipeCategory<SandPaperPolishingRe
 
 	@Override
 	public void addWidgets(CreateDisplay<SandPaperPolishingRecipe> display, List<Widget> ingredients, Point origin) {
-		List<ProcessingOutput> results = display.getRecipe().getRollableResults();
-
 		ingredients.add(basicSlot(origin.x + 27, origin.y + 29)
 				.markInput()
 				.entries(display.getInputEntries().get(0)));
-		ingredients.add(basicSlot(origin.x + 132, origin.y + 29)
-				.markOutput()
-				.entries(EntryIngredients.of(results.get(0).getStack())));
-
-		addStochasticTooltip(ingredients, results);
+		display.getRecipe().getRollableResults().stream().limit(1).forEach(result -> {
+			Slot outputSlot = basicSlot(origin.x + 132, origin.y + 29)
+					.markOutput()
+					.entries(EntryIngredients.of(result.getStack()));
+			ingredients.add(outputSlot);
+			addStochasticTooltip(outputSlot, result);
+		});
 	}
 
 	@Override


### PR DESCRIPTION
I made a mistake when trying to fix the problem of recipe chance in REI (#646, #902), which results in serveral REI crash issues (#1382, #1395, #1406, etc.) and leaves the chance display issue unsolved (#1393).

@TropheusJ fixed #1393 by avoid using the bulk version `CreateRecipeCategory::addStochasticTooltip(List<Widget>, List<ProcessingOutput>, int)`, and I think it can be better not to use it at all. For all current use cases, they can alternatively just add tooltip right after any slot created, and I think it is much more straight-forward. In other words, `addStochasticTooltip(Slot slot, ProcessingOutput output)` is sufficient to all current usages.

@IThundxr fixed #1382 (and all those crashes) by detecting illegal indexing [here](https://github.com/Fabricators-of-Create/Create/commit/2551fd4a5d508bb2d5e0a76ac4fe9e9fce91428b), which does not fixed the root cause where `slotIndex` is computed incorrectly in `CreateRecipeCategory::addStochasticTooltip(List<Widget>, List<ProcessingOutput>, int)`. It means that any recipe using the bulk version function would put output chance incorrectly to other slots.

For now, deploying, polishing and basin (including mixing and compacting) recipes are still using the bulk version function. Once a customized recipe with chance is added (via mod, datapack, KubeJS, etc.), the problem will float on the table.

In this pull request, I introduced `addStochasticTooltip(Slot slot, ProcessingOutput output)` and removed all other overloads.