### PR TITLE
Add compatibility for Shoulder Surfing Reloaded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ repositories {
     maven { url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/" } // Forge Config API Port
     maven { url = "https://maven.tterrag.com/" } // Flywheel
     maven { url = "https://maven.shedaniel.me/" } // REI and deps
-    maven { url = "https://api.modrinth.com/maven" } // LazyDFU, Sodium, Sandwichable
+    maven { url = "https://api.modrinth.com/maven" } // LazyDFU, Sodium, Sandwichable, ShoulderSurfing
     maven { url = "https://maven.terraformersmc.com/" } // Mod Menu, Trinkets
     maven { url = "https://squiddev.cc/maven" } // CC:T
     maven { url = "https://modmaven.dev" } // Botania
@@ -105,6 +105,7 @@ def compat(DependencyHandler deps) {
     deps.modCompileOnly("com.terraformersmc:modmenu:$modmenu_version")
     deps.modCompileOnly("maven.modrinth:sandwichable:$sandwichable_version")
     deps.modCompileOnly("maven.modrinth:sodium:$sodium_version")
+    deps.modCompileOnly("maven.modrinth:shoulder-surfing-reloaded:$shoulder_surfing_version")
 
     deps.modCompileOnly("dev.emi:trinkets:$trinkets_version")
     // for Trinkets

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,6 +62,9 @@ indium_version = 1.0.30+mc1.20.4
 trinkets_version = 3.7.0
 # for Trinkets - https://modrinth.com/mod/cardinal-components-api/versions
 cca_version = 5.2.1
+# https://modrinth.com/mod/shoulder-surfing-reloaded
+# 1.20.1-4.1.3 fabric
+shoulder_surfing_version = FPoDW3eS
 
 # Whether CC: Tweaked should be enabled in dev or not
 cc_enabled = false

--- a/src/main/java/com/simibubi/create/compat/Mods.java
+++ b/src/main/java/com/simibubi/create/compat/Mods.java
@@ -32,7 +32,8 @@ public enum Mods {
 	MODMENU,
 	BOTANIA,
 	SODIUM,
-	INDIUM;
+	INDIUM,
+	SHOULDERSURFING;
 
 	private final String id;
 	private final boolean loaded;

--- a/src/main/java/com/simibubi/create/compat/shouldersurfing/ShoulderSurfingPlugin.java
+++ b/src/main/java/com/simibubi/create/compat/shouldersurfing/ShoulderSurfingPlugin.java
@@ -1,0 +1,21 @@
+package com.simibubi.create.compat.shouldersurfing;
+
+import com.github.exopandora.shouldersurfing.api.callback.ITargetCameraOffsetCallback;
+import com.github.exopandora.shouldersurfing.api.client.IShoulderSurfing;
+import com.github.exopandora.shouldersurfing.api.plugin.IShoulderSurfingPlugin;
+import com.github.exopandora.shouldersurfing.api.plugin.IShoulderSurfingRegistrar;
+import com.simibubi.create.content.trains.CameraDistanceModifier;
+
+import net.minecraft.world.phys.Vec3;
+
+public class ShoulderSurfingPlugin implements IShoulderSurfingPlugin {
+	@Override
+	public void register(IShoulderSurfingRegistrar registrar) {
+		registrar.registerTargetCameraOffsetCallback(new ITargetCameraOffsetCallback() {
+			@Override
+			public Vec3 post(IShoulderSurfing instance, Vec3 targetOffset, Vec3 defaultOffset) {
+				return targetOffset.multiply(1, 1, CameraDistanceModifier.getMultiplier());
+			}
+		});
+	}
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/ContraptionHandlerClient.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/ContraptionHandlerClient.java
@@ -5,6 +5,10 @@ import java.util.Collection;
 
 import javax.annotation.Nullable;
 
+import com.github.exopandora.shouldersurfing.api.client.ShoulderSurfing;
+import com.github.exopandora.shouldersurfing.api.model.PickContext;
+import com.simibubi.create.compat.Mods;
+
 import net.minecraft.world.phys.HitResult;
 
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -129,8 +133,14 @@ public class ContraptionHandlerClient {
 	@Environment(EnvType.CLIENT)
 	public static Couple<Vec3> getRayInputs(LocalPlayer player) {
 		Minecraft mc = Minecraft.getInstance();
-		Vec3 origin = RaycastHelper.getTraceOrigin(player);
 		double reach = ReachEntityAttributes.getReachDistance(player, mc.gameMode.getPickRange());
+		if (Mods.SHOULDERSURFING.isLoaded() && ShoulderSurfing.getInstance().isShoulderSurfing()) {
+			var blockTrace = new PickContext.Builder(mc.gameRenderer.getMainCamera())
+				.build()
+				.blockTrace(reach, mc.getDeltaFrameTime());
+			return Couple.create(blockTrace.left(), blockTrace.right());
+		}
+		Vec3 origin = RaycastHelper.getTraceOrigin(player);
 		if (mc.hitResult != null && mc.hitResult.getLocation() != null)
 			reach = Math.min(mc.hitResult.getLocation()
 				.distanceTo(origin), reach);

--- a/src/main/resources/shouldersurfing_plugin.json
+++ b/src/main/resources/shouldersurfing_plugin.json
@@ -1,0 +1,3 @@
+{
+	"entrypoint": "com.simibubi.create.compat.shouldersurfing.ShoulderSurfingPlugin"
+}


### PR DESCRIPTION
This PR adds compatibility with the third person camera mod "Shoulder Surfing Reloaded". The following compatibility issues are addressed:
- Block interaction did not work properly for contraptions, as the raycast vector was not offset correctly (2nd commit)
- Third person camera multiplier did not work (3rd commit)

There may be more that I'm currently not aware of. Please let me know if you find one!

If this PR gets merged, I would also port this compatibility feature to the Forge repository and to other Minecraft versions.