### PR TITLE
Fix ingredients overlapping with heat bar when using EMI

### DIFF
--- a/src/main/java/com/simibubi/create/compat/emi/recipes/basin/BasinEmiRecipe.java
+++ b/src/main/java/com/simibubi/create/compat/emi/recipes/basin/BasinEmiRecipe.java
@@ -67,7 +67,7 @@ public class BasinEmiRecipe extends CreateEmiRecipe<BasinRecipe> {
 
 		for (int i = 0; i < inputSize; i++) {
 			EmiIngredient stack = input.get(i);
-			addSlot(widgets, stack, xOff + 16 + (i % 3) * 19, yOff + 50 + (i / 3) * 19 - (inputSize - 1) / 3 * 19);
+			addSlot(widgets, stack, xOff + 16 + (i % 3) * 19, yOff + 50 - (i / 3) * 19);
 		}
 
 		for (int i = 0; i < outputSize; i++) {

--- a/src/main/java/com/simibubi/create/compat/emi/recipes/basin/BasinEmiRecipe.java
+++ b/src/main/java/com/simibubi/create/compat/emi/recipes/basin/BasinEmiRecipe.java
@@ -64,10 +64,11 @@ public class BasinEmiRecipe extends CreateEmiRecipe<BasinRecipe> {
 
 		int xOff = inputSize < 3 ? (3 - inputSize) * 19 / 2 : 0;
 		int yOff = 0;
+		int iRows = 1 + (inputSize - 1) / 3;
 
 		for (int i = 0; i < inputSize; i++) {
 			EmiIngredient stack = input.get(i);
-			addSlot(widgets, stack, xOff + 16 + (i % 3) * 19, yOff + 50 + (i / 3) * 19);
+			addSlot(widgets, stack, xOff + 16 + (i % 3) * 19, yOff + 50 + (i / 3) * 19 - (iRows - 1) * 19);
 		}
 
 		for (int i = 0; i < outputSize; i++) {

--- a/src/main/java/com/simibubi/create/compat/emi/recipes/basin/BasinEmiRecipe.java
+++ b/src/main/java/com/simibubi/create/compat/emi/recipes/basin/BasinEmiRecipe.java
@@ -64,11 +64,10 @@ public class BasinEmiRecipe extends CreateEmiRecipe<BasinRecipe> {
 
 		int xOff = inputSize < 3 ? (3 - inputSize) * 19 / 2 : 0;
 		int yOff = 0;
-		int iRows = 1 + (inputSize - 1) / 3;
 
 		for (int i = 0; i < inputSize; i++) {
 			EmiIngredient stack = input.get(i);
-			addSlot(widgets, stack, xOff + 16 + (i % 3) * 19, yOff + 50 + (i / 3) * 19 - (iRows - 1) * 19);
+			addSlot(widgets, stack, xOff + 16 + (i % 3) * 19, yOff + 50 + (i / 3) * 19 - (inputSize - 1) / 3 * 19);
 		}
 
 		for (int i = 0; i < outputSize; i++) {


### PR DESCRIPTION
When there is more than one row of ingredients in any Basin recipe, some ingredients will overlap with the heat bar when using EMI as the recipe viewer.

![before](https://github.com/user-attachments/assets/e97ad86d-67e1-495f-91ce-c5ed0abe7d9e)

My PR fixes this issue by adding extra rows above the first row instead of below it

![after](https://github.com/user-attachments/assets/3909a23a-cddd-41c0-af38-94621a7d73ab)

