### PR TITLE
Add support for trains crossing Better End portals

### DIFF
--- a/src/main/java/com/simibubi/create/compat/Mods.java
+++ b/src/main/java/com/simibubi/create/compat/Mods.java
@@ -19,6 +19,7 @@ import net.minecraft.world.level.block.Block;
  */
 public enum Mods {
 	AETHER,
+	BETTEREND,
 	COMPUTERCRAFT,
 	CONNECTIVITY,
 	CURIOS,

--- a/src/main/java/com/simibubi/create/content/trains/track/AllPortalTracks.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/AllPortalTracks.java
@@ -31,37 +31,75 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.portal.PortalInfo;
 import net.minecraft.world.phys.AABB;
-
 import net.minecraft.world.phys.Vec3;
 
 import org.slf4j.Logger;
 import com.mojang.logging.LogUtils;
 
+/**
+ * Manages portal track integrations for various dimensions and mods within the Create mod.
+ * <p>
+ * Portals must be entered from the side and must lead to a different dimension than the one entered from.
+ * This class handles the registration and functionality of portal tracks for standard and modded portals.
+ * </p>
+ */
 public class AllPortalTracks {
-	// Portals must be entered from the side and must lead to a different dimension
-	// than the one entered from
 
 	private static final Logger LOGGER = LogUtils.getLogger();
 
+	/**
+	 * Functional interface representing a provider for portal track connections.
+	 * It takes a pair of {@link ServerLevel} and {@link BlockFace} representing the inbound track
+	 * and returns a similar pair for the outbound track.
+	 */
 	@FunctionalInterface
 	public interface PortalTrackProvider extends UnaryOperator<Pair<ServerLevel, BlockFace>> {
 	}
 
+	/**
+	 * Registry mapping portal blocks to their respective {@link PortalTrackProvider}s.
+	 */
 	private static final AttachedRegistry<Block, PortalTrackProvider> PORTAL_BEHAVIOURS =
-		new AttachedRegistry<>(BuiltInRegistries.BLOCK);
+			new AttachedRegistry<>(BuiltInRegistries.BLOCK);
 
+	/**
+	 * Registers a portal track integration for a given block identified by its {@link ResourceLocation}.
+	 *
+	 * @param block    The resource location of the portal block.
+	 * @param provider The portal track provider for the block.
+	 */
 	public static void registerIntegration(ResourceLocation block, PortalTrackProvider provider) {
 		PORTAL_BEHAVIOURS.register(block, provider);
 	}
 
+	/**
+	 * Registers a portal track integration for a given {@link Block}.
+	 *
+	 * @param block    The portal block.
+	 * @param provider The portal track provider for the block.
+	 */
 	public static void registerIntegration(Block block, PortalTrackProvider provider) {
 		PORTAL_BEHAVIOURS.register(block, provider);
 	}
 
+	/**
+	 * Checks if a given {@link BlockState} represents a supported portal block.
+	 *
+	 * @param state The block state to check.
+	 * @return {@code true} if the block state represents a supported portal; {@code false} otherwise.
+	 */
 	public static boolean isSupportedPortal(BlockState state) {
 		return PORTAL_BEHAVIOURS.get(state.getBlock()) != null;
 	}
 
+	/**
+	 * Retrieves the corresponding outbound track on the other side of a portal.
+	 *
+	 * @param level        The current {@link ServerLevel}.
+	 * @param inboundTrack The inbound track {@link BlockFace}.
+	 * @return A pair containing the target {@link ServerLevel} and outbound {@link BlockFace},
+	 *         or {@code null} if no corresponding portal is found.
+	 */
 	public static Pair<ServerLevel, BlockFace> getOtherSide(ServerLevel level, BlockFace inboundTrack) {
 		BlockPos portalPos = inboundTrack.getConnectedPos();
 		BlockState portalState = level.getBlockState(portalPos);
@@ -69,8 +107,12 @@ public class AllPortalTracks {
 		return provider == null ? null : provider.apply(Pair.of(level, inboundTrack));
 	}
 
-	// Builtin handlers
+	// Built-in handlers
 
+	/**
+	 * Registers default portal track integrations for built-in dimensions and mods.
+	 * This includes the Nether, Aether (if loaded), and Better End (if loaded).
+	 */
 	public static void registerDefaults() {
 		registerIntegration(Blocks.NETHER_PORTAL, AllPortalTracks::nether);
 		if (Mods.AETHER.isLoaded())
@@ -79,6 +121,12 @@ public class AllPortalTracks {
 			registerIntegration(new ResourceLocation("betterend", "end_portal_block"), AllPortalTracks::betterend);
 	}
 
+	/**
+	 * Portal track provider for the Nether portal.
+	 *
+	 * @param inbound A pair containing the current {@link ServerLevel} and inbound {@link BlockFace}.
+	 * @return A pair with the target {@link ServerLevel} and outbound {@link BlockFace}, or {@code null} if not applicable.
+	 */
 	private static Pair<ServerLevel, BlockFace> nether(Pair<ServerLevel, BlockFace> inbound) {
 		ServerLevel level = inbound.getFirst();
 		MinecraftServer minecraftServer = level.getServer();
@@ -89,14 +137,20 @@ public class AllPortalTracks {
 		return standardPortalProvider(inbound, Level.OVERWORLD, Level.NETHER, AllPortalTracks::getTeleporter);
 	}
 
+	/**
+	 * Portal track provider for the Aether mod's portal.
+	 *
+	 * @param inbound A pair containing the current {@link ServerLevel} and inbound {@link BlockFace}.
+	 * @return A pair with the target {@link ServerLevel} and outbound {@link BlockFace}, or {@code null} if not applicable.
+	 */
 	private static Pair<ServerLevel, BlockFace> aether(Pair<ServerLevel, BlockFace> inbound) {
 		ResourceKey<Level> aetherLevelKey =
-			ResourceKey.create(Registries.DIMENSION, new ResourceLocation("aether", "the_aether"));
+				ResourceKey.create(Registries.DIMENSION, new ResourceLocation("aether", "the_aether"));
 		return standardPortalProvider(inbound, Level.OVERWORLD, aetherLevelKey, level -> {
 			try {
 				return (ITeleporter) Class.forName("com.aetherteam.aether.block.portal.AetherPortalForcer")
-					.getDeclaredConstructor(ServerLevel.class, boolean.class)
-					.newInstance(level, true);
+						.getDeclaredConstructor(ServerLevel.class, boolean.class)
+						.newInstance(level, true);
 			} catch (Exception e) {
 				LOGGER.error("Failed to create Aether teleporter: ", e);
 			}
@@ -104,6 +158,12 @@ public class AllPortalTracks {
 		});
 	}
 
+	/**
+	 * Portal track provider for the Better End mod's portal.
+	 *
+	 * @param inbound A pair containing the current {@link ServerLevel} and inbound {@link BlockFace}.
+	 * @return A pair with the target {@link ServerLevel} and outbound {@link BlockFace}, or {@code null} if not applicable.
+	 */
 	private static Pair<ServerLevel, BlockFace> betterend(Pair<ServerLevel, BlockFace> inbound) {
 		return portalProvider(
 				inbound,
@@ -113,6 +173,13 @@ public class AllPortalTracks {
 		);
 	}
 
+	/**
+	 * Retrieves the adjusted {@link PortalInfo} for the Better End portal using reflection.
+	 *
+	 * @param entity      The probe {@link Entity} used for portal traversal calculations.
+	 * @param targetLevel The target {@link ServerLevel} (dimension).
+	 * @return The adjusted {@link PortalInfo} for the target dimension, or {@code null} if an error occurs.
+	 */
 	private static PortalInfo getBetterEndPortalInfo(Entity entity, ServerLevel targetLevel) {
 		try {
 			Class<?> travelerStateClass = Class.forName("org.betterx.betterend.portal.TravelerState");
@@ -120,7 +187,7 @@ public class AllPortalTracks {
 			constructor.setAccessible(true);
 			Object travelerState = constructor.newInstance(entity);
 
-			// Set the private portalEntrancePos field to the portalPos as assumed in TravelerState#findDimensionEntryPoint
+			// Set the private portalEntrancePos field to the entity's block position as assumed in TravelerState#findDimensionEntryPoint
 			Field portalEntrancePosField = travelerStateClass.getDeclaredField("portalEntrancePos");
 			portalEntrancePosField.setAccessible(true);
 			portalEntrancePosField.set(travelerState, entity.blockPosition().immutable());
@@ -128,10 +195,10 @@ public class AllPortalTracks {
 			Method findDimensionEntryPointMethod = travelerStateClass.getDeclaredMethod("findDimensionEntryPoint", ServerLevel.class);
 			findDimensionEntryPointMethod.setAccessible(true);
 
-			// we need to lower the result by 1 to get level with the floor on the exit side
+			// We need to lower the result by 1 to align with the floor on the exit side
 			PortalInfo otherSide = (PortalInfo) findDimensionEntryPointMethod.invoke(travelerState, targetLevel);
 			return new PortalInfo(
-					(new Vec3(otherSide.pos.x, otherSide.pos.y - 1, otherSide.pos.z)),
+					new Vec3(otherSide.pos.x, otherSide.pos.y - 1, otherSide.pos.z),
 					otherSide.speed,
 					otherSide.yRot,
 					otherSide.xRot
@@ -148,10 +215,25 @@ public class AllPortalTracks {
 		return null;
 	}
 
+	/**
+	 * Retrieves the default {@link ITeleporter} for a given {@link ServerLevel}.
+	 *
+	 * @param level The server level.
+	 * @return The teleporter associated with the level.
+	 */
 	private static ITeleporter getTeleporter(ServerLevel level) {
 		return (ITeleporter) level.getPortalForcer();
 	}
 
+	/**
+	 * Provides a standard portal track provider that handles portal traversal between two dimensions.
+	 *
+	 * @param inbound             A pair containing the current {@link ServerLevel} and inbound {@link BlockFace}.
+	 * @param firstDimension      The first dimension (typically the Overworld).
+	 * @param secondDimension     The second dimension (e.g., Nether, Aether).
+	 * @param customPortalForcer  A function to obtain the {@link ITeleporter} for the target level.
+	 * @return A pair with the target {@link ServerLevel} and outbound {@link BlockFace}, or {@code null} if not applicable.
+	 */
 	private static Pair<ServerLevel, BlockFace> standardPortalProvider(
 			Pair<ServerLevel, BlockFace> inbound,
 			ResourceKey<Level> firstDimension,
@@ -169,6 +251,15 @@ public class AllPortalTracks {
 		);
 	}
 
+	/**
+	 * Generalized portal provider method that calculates the corresponding outbound track across a portal.
+	 *
+	 * @param inbound             A pair containing the current {@link ServerLevel} and inbound {@link BlockFace}.
+	 * @param firstDimension      The first dimension.
+	 * @param secondDimension     The second dimension.
+	 * @param portalInfoProvider  A function that provides the {@link PortalInfo} given the target level and probe entity.
+	 * @return A pair with the target {@link ServerLevel} and outbound {@link BlockFace}, or {@code null} if not applicable.
+	 */
 	private static Pair<ServerLevel, BlockFace> portalProvider(
 			Pair<ServerLevel, BlockFace> inbound,
 			ResourceKey<Level> firstDimension,


### PR DESCRIPTION
This diff adds support for trains crossing Better End portals.

It has been tested successfully with Better End 4.0.11 on Minecraft 1.20.1 with Fabric Loader 0.16.3. To recreate this test, download the Better End mod and its dependency library, bclib 3.0.14

I also added javadocs for AllPortalTracks, but those were added in a separate commit in case they aren't wanted.