### PR TITLE
Fix goggles not equipable into trinkets face slot

### DIFF
--- a/src/main/resources/data/trinkets/tags/items/head/face.json
+++ b/src/main/resources/data/trinkets/tags/items/head/face.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "create:goggles"
+  ]
+}


### PR DESCRIPTION
This fixes Goggles not being equippable into the `face` slot despite the slot registration.