### PR TITLE
Fix deployer retaining damage after item was pulled off the hand

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
@@ -133,7 +133,7 @@ public class DeployerHandler {
 			.addTransientAttributeModifiers(attributeModifiers);
 		activateInner(player, vec, clickedPos, extensionVector, mode);
 		player.getAttributes()
-			.addTransientAttributeModifiers(attributeModifiers);
+			.removeAttributeModifiers(attributeModifiers);
 	}
 
 	private static void activateInner(DeployerFakePlayer player, Vec3 vec, BlockPos clickedPos, Vec3 extensionVector,


### PR DESCRIPTION
Fixes #1676

I do not understand why `addTransientAttributeModifiers` was called again after performing the action? I assume this might be just a copy mistake that wasn't noticed for a while.