### PR TITLE
Add minecraft:bowl to upright_on_belt item tag

### DIFF
--- a/src/generated/resources/data/create/tags/items/upright_on_belt.json
+++ b/src/generated/resources/data/create/tags/items/upright_on_belt.json
@@ -5,6 +5,7 @@
     "create:blaze_cake",
     "create:creative_blaze_cake",
     "create:builders_tea",
+    "minecraft:bowl",
     "minecraft:glass_bottle",
     "minecraft:potion",
     "minecraft:splash_potion",


### PR DESCRIPTION
Really feel like the bowl should be there considering that the Glass Bottle is also there, could just be me tho