### PR TITLE
Adjust transparency face-hiding logic for copycat panels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ local.properties
 /linkie-cache/
 
 .DS_Store
+*.md
 #/libs/
 
 # don't push local Ponder

--- a/src/main/java/com/simibubi/create/content/decoration/copycat/CopycatPanelBlock.java
+++ b/src/main/java/com/simibubi/create/content/decoration/copycat/CopycatPanelBlock.java
@@ -171,7 +171,9 @@ public class CopycatPanelBlock extends WaterloggedCopycatBlock {
 
 	@Override
 	public boolean skipRendering(BlockState state, BlockState adjacentState, Direction direction) {
-		return state.equals(adjacentState) && direction.getAxis().isHorizontal();
+		// Rely on hidesNeighborFace for correctness as panels do not occupy full blocks
+		// This prevents the flat face from disappearing when two upright panels are adjacent.
+		return false;
 	}
 
 	@Override
@@ -182,12 +184,14 @@ public class CopycatPanelBlock extends WaterloggedCopycatBlock {
 	@Override
 	public boolean hidesNeighborFace(BlockGetter level, BlockPos pos, BlockState state, BlockState neighborState,
 									 Direction dir) {
-		if (state.is(this) == neighborState.is(this)) {
+		if (neighborState.is(this)) {
+			// Matching orientations should merge visually
 			if (CopycatSpecialCases.isBarsMaterial(getMaterial(level, pos))
 				&& CopycatSpecialCases.isBarsMaterial(getMaterial(level, pos.relative(dir))))
 				return state.getValue(FACING) == neighborState.getValue(FACING);
-			if (getMaterial(level, pos).skipRendering(getMaterial(level, pos.relative(dir)), dir.getOpposite()))
-				return isOccluded(state, neighborState, dir.getOpposite());
+
+			// Otherwise let connected textures handle blending without hiding.
+			return false;
 		}
 
 		return state.getValue(FACING) == dir.getOpposite()


### PR DESCRIPTION
This fixes an issue where adjacent copycat panel blocks would hide one of the faces touching the occupied block

Addresses [1738](https://github.com/Fabricators-of-Create/Create/issues/1738)

<img width="856" height="512" alt="image" src="https://github.com/user-attachments/assets/2eeca3ba-e52b-40ce-a39e-a961e00c81d1" />
<img width="856" height="512" alt="image" src="https://github.com/user-attachments/assets/daf54021-b2a4-4e11-9bf9-adf236a04d02" />
