### PR TITLE
Fix limestone & scoria generation

### DIFF
--- a/src/main/java/com/simibubi/create/AllFluids.java
+++ b/src/main/java/com/simibubi/create/AllFluids.java
@@ -20,6 +20,11 @@ import com.simibubi.create.foundation.fluid.FluidHelper;
 import com.tterrag.registrate.fabric.SimpleFlowableFluid;
 import com.tterrag.registrate.util.entry.FluidEntry;
 
+import io.github.fabricators_of_create.porting_lib.fluids.FluidInteractionRegistry;
+
+import io.github.fabricators_of_create.porting_lib.fluids.FluidInteractionRegistry.InteractionInformation;
+import io.github.fabricators_of_create.porting_lib.fluids.PortingLibFluids;
+
 import net.createmod.catnip.data.Iterate;
 import net.createmod.catnip.nbt.NBTHelper;
 import net.minecraft.core.BlockPos;
@@ -165,7 +170,15 @@ public class AllFluids {
 	}
 
 	public static void registerFluidInteractions() {
-		// fabric: no fluid interaction API, use legacy method
+		FluidInteractionRegistry.addInteraction(PortingLibFluids.LAVA_TYPE, new InteractionInformation(
+			((level, currentPos, relativePos, currentState) -> level.getFluidState(relativePos).getType().isSame(HONEY.get())),
+			AllPaletteStoneTypes.LIMESTONE.getBaseBlock().get().defaultBlockState()
+		));
+		FluidInteractionRegistry.addInteraction(PortingLibFluids.LAVA_TYPE, new InteractionInformation(
+			((level, currentPos, relativePos, currentState) -> level.getFluidState(relativePos).getType().isSame(CHOCOLATE.get())),
+			AllPaletteStoneTypes.SCORIA.getBaseBlock().get().defaultBlockState()
+		));
+
 		FluidPlaceBlockCallback.EVENT.register(AllFluids::whenFluidsMeet);
 	}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/drill/CobbleGenOptimisation.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/drill/CobbleGenOptimisation.java
@@ -58,7 +58,7 @@ public class CobbleGenOptimisation {
 			FluidState fluidState = config.statesAroundDrill.get(i)
 				.getFluidState();
 			FluidType fluidType = fluidState.getFluidType();
-			if (!fluidType.isAir() && interactions.get(fluidType) != null)
+			if (fluidType != null && !fluidType.isAir() && interactions.get(fluidType) != null)
 				presentFluidTypes.put(fluidType, Pair.of(Iterate.directions[i], fluidState));
 		}
 
@@ -93,7 +93,7 @@ public class CobbleGenOptimisation {
 		ServerLevel owLevel = level.getServer().getLevel(Level.OVERWORLD);
 		if (owLevel == null)
 			owLevel = level;
-		
+
 		if (cachedLevel == null || cachedLevel.getLevel() != owLevel)
 			cachedLevel = new CobbleGenLevel(level);
 


### PR DESCRIPTION
This PR fixes limestone & scoria generation with the drill optimization by adding a null check for the FluidType and registering the interactions to Porting Lib.
Closes #1834 