### PR TITLE
fix: Fix the crash problem of postbox

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
@@ -103,19 +103,34 @@ public class ItemHelper {
 		float f = 0.0F;
 		int totalSlots = 0;
 
-		try (Transaction t = TransferUtil.getTransaction()) {
-			for (StorageView<ItemVariant> view : inv) {
-				long slotLimit = view.getCapacity();
-				if (slotLimit == 0) {
-					continue;
+			// Try to open a transaction for stable reads. If we're inside a Transaction.close() callback,
+			// Fabric forbids starting/inspecting the current transaction and will throw IllegalStateException.
+			// In that case, fall back to reading without creating a new transaction.
+			try {
+				try (Transaction t = TransferUtil.getTransaction()) {
+					for (StorageView<ItemVariant> view : inv) {
+						long slotLimit = view.getCapacity();
+						if (slotLimit == 0) {
+							continue;
+						}
+						totalSlots++;
+						if (!view.isResourceBlank()) {
+							f += (float) view.getAmount() / (float) Math.min(slotLimit, view.getResource().getItem().getMaxStackSize());
+							++i;
+						}
+					}
 				}
-				totalSlots++;
-				if (!view.isResourceBlank()) {
-					f += (float) view.getAmount() / (float) Math.min(slotLimit, view.getResource().getItem().getMaxStackSize());
-					++i;
+			} catch (IllegalStateException e) {
+				for (StorageView<ItemVariant> view : inv) {
+					long slotLimit = view.getCapacity();
+					if (slotLimit == 0) continue;
+					totalSlots++;
+					if (!view.isResourceBlank()) {
+						f += (float) view.getAmount() / (float) Math.min(slotLimit, view.getResource().getItem().getMaxStackSize());
+						++i;
+					}
 				}
 			}
-		}
 
 		if (totalSlots == 0)
 			return 0;


### PR DESCRIPTION
Detailed bug reproduce see [https://github.com/Creators-of-Create/Create/issues/9785](https://github.com/Creators-of-Create/Create/issues/9785)
Below is a copy of the original issue (Written by @Sukiet):

# Context
## Full sequence
1. A chute inserts items into a white postbox.
2. The inventory-change callback notifies neighbouring blocks.
3. A redstone comparator next to the postbox asks for the analog signal strength.
4. Create’s ItemHelper.calcRedstoneFromInventory() calls TransferUtil.getTransaction() to access the item cache.
5. This runs inside a Transaction.close() callback; Fabric API forbids getCurrentUnsafe() at that moment and throws IllegalStateException.
6. The exception is caught as a “Ticking block entity” error and the server is killed.
## How to reproduce
1. Place a white postbox.
2. Put a redstone comparator against the postbox so it reads the fill level.
3. Insert items through Create logistics (chutes, funnels, etc.).
4. Wait for item transfer -> instant crash.
<img width="2560" height="1334" alt="image" src="https://github.com/user-attachments/assets/5fa5d950-0efd-44b2-a4c1-ea1dc8f0a54b" />

# Crash Report
[https://mclo.gs/TXsULuX](https://mclo.gs/TXsULuX)