### PR TITLE
Update dependencies for Slice & Dice and Create Jetpack

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -94,8 +94,8 @@
     "create_power_loader": "<=1.4.2",
     "createbigcannons": "<=0.5.3",
     "copycats": "<=1.1.1",
-    "sliceanddice": "<=3.0.0",
-    "create_jetpack": "<=4.1.1",
+    "sliceanddice": "<3.4.1-fabric",
+    "create_jetpack": "<4.3.1-fabric",
     "createorigins": "<=1.2.1",
     "exposure": "<=1.4.0",
     "cobblegen": "<=5.3.2"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -95,7 +95,7 @@
     "createbigcannons": "<=0.5.3",
     "copycats": "<=1.1.1",
     "sliceanddice": "<3.4.1-fabric",
-    "create_jetpack": "<4.3.1-fabric",
+    "create_jetpack": "<4.4.0-fabric",
     "createorigins": "<=1.2.1",
     "exposure": "<=1.4.0",
     "cobblegen": "<=5.3.2"


### PR DESCRIPTION
I am in the process of updating these mods to work with the 6.* releases. Since you kept a list of incompatible versions already in your mod definition (thank you), it would make sense to update them to check against the new 6.* compatible versions