### PR TITLE
Fix cannon not using up gunpowder from outside storage

### DIFF
--- a/src/main/java/com/simibubi/create/content/schematics/cannon/SchematicannonBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/schematics/cannon/SchematicannonBlockEntity.java
@@ -674,9 +674,12 @@ public class SchematicannonBlockEntity extends SmartBlockEntity implements MenuP
 					if (storage == null)
 						continue;
 					long amountExtracted = storage.extract(ItemVariant.of(Items.GUNPOWDER), 1, t);
-					if (amountExtracted > 0)
-						externalGunpowderFound = true;
+					if (amountExtracted == 0)
+						continue;
+					externalGunpowderFound = true;
+					break;
 				}
+				t.commit();
 			}
 			if (!externalGunpowderFound)
 				return;

--- a/src/main/java/com/simibubi/create/content/schematics/cannon/SchematicannonBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/schematics/cannon/SchematicannonBlockEntity.java
@@ -679,10 +679,11 @@ public class SchematicannonBlockEntity extends SmartBlockEntity implements MenuP
 					externalGunpowderFound = true;
 					break;
 				}
+
+				if (!externalGunpowderFound)
+					return;
 				t.commit();
 			}
-			if (!externalGunpowderFound)
-				return;
 		}
 
 		remainingFuel += getShotsPerGunpowder();


### PR DESCRIPTION
And break of course after we find gunpowder so we don't take from multiple inventories at once. Written via a continue as that aligns closer with the upstream code.