### PR TITLE
Fixed certus_quartz.json

### DIFF
--- a/src/generated/resources/data/create/recipes/milling/compat/ae2/certus_quartz.json
+++ b/src/generated/resources/data/create/recipes/milling/compat/ae2/certus_quartz.json
@@ -10,7 +10,7 @@
   "type": "create:milling",
   "ingredients": [
     {
-      "tag": "c:certus_quartz/gems"
+      "tag": "ae2:all_certus_quartz"
     }
   ],
   "processingTime": 200,


### PR DESCRIPTION
In-game the recipe was showing up with a blank input. By changing the tag to ae2:all_certus_quartz it works properly